### PR TITLE
chore: update to ECL 2.1.0

### DIFF
--- a/src/ec/.storybook/config.js
+++ b/src/ec/.storybook/config.js
@@ -3,7 +3,7 @@ import { withOptions } from '@storybook/addon-options';
 
 addDecorator(
   withOptions({
-    name: 'ECL v2 - EC Twig',
+    name: 'ECL v2.1 - EC Twig',
     url: 'https://github.com/ec-europa/ecl-twig',
   })
 );

--- a/src/ec/.storybook/preview-head.html
+++ b/src/ec/.storybook/preview-head.html
@@ -1,9 +1,9 @@
 <link
   rel="stylesheet"
   type="text/css"
-  href="https://unpkg.com/@ecl/ec-preset-website@2.0.0/dist/styles/ecl-ec-preset-website.css"
+  href="https://unpkg.com/@ecl/ec-preset-website@2.1.0/dist/styles/ecl-ec-preset-website.css"
 />
 <script
   defer
-  src="https://unpkg.com/@ecl/ec-preset-website@2.0.0/dist/scripts/ecl-ec-preset-website.js"
+  src="https://unpkg.com/@ecl/ec-preset-website@2.1.0/dist/scripts/ecl-ec-preset-website.js"
 ></script>

--- a/src/ec/packages/ec-component-icon/__snapshots__/icon.test.js.snap
+++ b/src/ec/packages/ec-component-icon/__snapshots__/icon.test.js.snap
@@ -14,6 +14,13 @@ exports[`EC - Icon Branded - icon google-plus renders correctly 1`] = `
 "
 `;
 
+exports[`EC - Icon Branded - icon instagram renders correctly 1`] = `
+"<svg class=\\"ecl-icon ecl-icon--m\\" focusable=\\"false\\" aria-hidden=\\"true\\">
+  <use xlink:href=\\"static/icons.svg#branded--instagram\\"></use>
+</svg>
+"
+`;
+
 exports[`EC - Icon Branded - icon linkedin renders correctly 1`] = `
 "<svg class=\\"ecl-icon ecl-icon--m\\" focusable=\\"false\\" aria-hidden=\\"true\\">
   <use xlink:href=\\"static/icons.svg#branded--linkedin\\"></use>

--- a/src/ec/packages/ec-component-icon/package.json
+++ b/src/ec/packages/ec-component-icon/package.json
@@ -8,7 +8,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@ecl/ec-resources-icons": "~2.1.0"
+    "@ecl/ec-resources-icons": "~2.1.0",
+    "@ecl/ec-specs-icon": "~2.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/ec/packages/ec-component-icon/package.json
+++ b/src/ec/packages/ec-component-icon/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@ecl/ec-resources-icons": "^2.0.0"
+    "@ecl/ec-resources-icons": "^2.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/ec/packages/ec-component-icon/package.json
+++ b/src/ec/packages/ec-component-icon/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@ecl/ec-resources-icons": "^2.1.0"
+    "@ecl/ec-resources-icons": "~2.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/eu/.storybook/config.js
+++ b/src/eu/.storybook/config.js
@@ -3,7 +3,7 @@ import { withOptions } from '@storybook/addon-options';
 
 addDecorator(
   withOptions({
-    name: 'ECL v2 - EU Twig',
+    name: 'ECL v2.1 - EU Twig',
     url: 'https://github.com/ec-europa/ecl-twig',
   })
 );

--- a/src/eu/.storybook/preview-head.html
+++ b/src/eu/.storybook/preview-head.html
@@ -1,9 +1,9 @@
 <link
   rel="stylesheet"
   type="text/css"
-  href="https://unpkg.com/@ecl/eu-preset-website@2.0.0/dist/styles/ecl-eu-preset-website.css"
+  href="https://unpkg.com/@ecl/eu-preset-website@2.1.0/dist/styles/ecl-eu-preset-website.css"
 />
 <script
   defer
-  src="https://unpkg.com/@ecl/eu-preset-website@2.0.0/dist/scripts/ecl-eu-preset-website.js"
+  src="https://unpkg.com/@ecl/eu-preset-website@2.1.0/dist/scripts/ecl-eu-preset-website.js"
 ></script>

--- a/src/eu/packages/eu-component-icon/package.json
+++ b/src/eu/packages/eu-component-icon/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@ecl/eu-resources-icons": "^2.0.0"
+    "@ecl/eu-resources-icons": "^2.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/eu/packages/eu-component-icon/package.json
+++ b/src/eu/packages/eu-component-icon/package.json
@@ -8,7 +8,8 @@
     "access": "public"
   },
   "devDependencies": {
-    "@ecl/eu-resources-icons": "~2.1.0"
+    "@ecl/eu-resources-icons": "~2.1.0",
+    "@ecl/eu-specs-icon": "~2.1.0"
   },
   "repository": {
     "type": "git",

--- a/src/eu/packages/eu-component-icon/package.json
+++ b/src/eu/packages/eu-component-icon/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@ecl/eu-resources-icons": "^2.1.0"
+    "@ecl/eu-resources-icons": "~2.1.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,7 +691,7 @@
   resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.0.0.tgz#4f917c42420583ef6d27e2c369b0005bdebc1350"
   integrity sha512-G0P9JI5PR7yQ8+/xeYoPfBdu7Gtz1KvNCVvjxcwOuu/361zlKx5BW0uNauurUqh6moHA7sjpV+TdW6PME/AFBQ==
 
-"@ecl/ec-resources-icons@^2.1.0":
+"@ecl/ec-resources-icons@~2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.1.0.tgz#d4ceb09c8f4180e5aaaacc3eaea766807c54f07b"
   integrity sha512-xk6cH2EIAJJQBZnUTd7fO4mJGdTarYuyGuecx2rKmiChvQVNlMAojArcH3qIz3DHbYNwFsmOQnaE5dKPvycFjw==
@@ -708,7 +708,7 @@
   dependencies:
     "@ecl/ec-resources-icons" "^2.0.0"
 
-"@ecl/eu-resources-icons@^2.1.0":
+"@ecl/eu-resources-icons@~2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@ecl/eu-resources-icons/-/eu-resources-icons-2.1.0.tgz#1b540156dc3e6bb64ce1e7e6e586cb001a2bb239"
   integrity sha512-cDNaQyNxQPlt5wgFqKqvX/gqjs63opquKyk0FoAQg7Zt5pdojYWu9Ytl81JW0UbUxxanhM14HTpJ0Fjsir2jIg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -708,10 +708,20 @@
   dependencies:
     "@ecl/ec-resources-icons" "^2.0.0"
 
+"@ecl/ec-specs-icon@~2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-specs-icon/-/ec-specs-icon-2.1.0.tgz#0177cdbd8000a4c149542626fc704b128cec5627"
+  integrity sha512-1YObv0apHhb/cngfRQIPdedt4ADz4X8ae0GDdWwvdovALT9FUH9jxCPVC5P1Qny+4SQ0psxz8EBsWyBzaBmlwA==
+
 "@ecl/eu-resources-icons@~2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@ecl/eu-resources-icons/-/eu-resources-icons-2.1.0.tgz#1b540156dc3e6bb64ce1e7e6e586cb001a2bb239"
   integrity sha512-cDNaQyNxQPlt5wgFqKqvX/gqjs63opquKyk0FoAQg7Zt5pdojYWu9Ytl81JW0UbUxxanhM14HTpJ0Fjsir2jIg==
+
+"@ecl/eu-specs-icon@~2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ecl/eu-specs-icon/-/eu-specs-icon-2.1.0.tgz#50dac80a3bbf2af082f0d0fd985541c4bf70113c"
+  integrity sha512-COVrfottqaceY3QN1ietN7gWqGQ5zD7jdVsjGwRfQcdF3aROM0Zj4mVJ28K9kV6+zh7DEtKpzrLGlkzv+o/CKQ==
 
 "@emotion/cache@^0.8.8":
   version "0.8.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,6 +691,11 @@
   resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.0.0.tgz#4f917c42420583ef6d27e2c369b0005bdebc1350"
   integrity sha512-G0P9JI5PR7yQ8+/xeYoPfBdu7Gtz1KvNCVvjxcwOuu/361zlKx5BW0uNauurUqh6moHA7sjpV+TdW6PME/AFBQ==
 
+"@ecl/ec-resources-icons@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.1.0.tgz#d4ceb09c8f4180e5aaaacc3eaea766807c54f07b"
+  integrity sha512-xk6cH2EIAJJQBZnUTd7fO4mJGdTarYuyGuecx2rKmiChvQVNlMAojArcH3qIz3DHbYNwFsmOQnaE5dKPvycFjw==
+
 "@ecl/ec-specs-blockquote@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-specs-blockquote/-/ec-specs-blockquote-2.0.0.tgz#57cbfe75e58e780fbb169dfe832d61b973c6876d"
@@ -702,6 +707,11 @@
   integrity sha512-31qIYaqGFNompLAJ9VoZygWzTl/YpEYYLDpCx5ewfhHii/tqkltaXNBWDBjTMS6gFLyJV66VYkZpuE+htAP2Hw==
   dependencies:
     "@ecl/ec-resources-icons" "^2.0.0"
+
+"@ecl/eu-resources-icons@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@ecl/eu-resources-icons/-/eu-resources-icons-2.1.0.tgz#1b540156dc3e6bb64ce1e7e6e586cb001a2bb239"
+  integrity sha512-cDNaQyNxQPlt5wgFqKqvX/gqjs63opquKyk0FoAQg7Zt5pdojYWu9Ytl81JW0UbUxxanhM14HTpJ0Fjsir2jIg==
 
 "@emotion/cache@^0.8.8":
   version "0.8.8"


### PR DESCRIPTION
Use latest version of ECl (2.1.0).
Components already merged have been updated (only icons currently)