### PR TITLE
docs: use `only` keyword

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# ECL Twig Documentation
+
+- [Decisions](./decisions/README.md)
+- [Conventions](./conventions.md)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -14,14 +14,34 @@ The `only` keyword disables access to the context, thus preventing leaks.
 {% include "./path/to/template.html.twig" only %}
 
 {% include "./path/to/template.html.twig" with {
-  var: "foo"
+  'foo': 'bar'
 } only %}
+
+{% embed "./path/to/template.html.twig" only %}
+  ...
+{% endembed %}
+
+{% embed "./path/to/template.html.twig" with {
+  'foo': 'bar'
+} only %}
+  ...
+{% endembed %}
 
 
 <!-- Don't -->
 {% include "./path/to/template.html.twig" %}
 
 {% include "./path/to/template.html.twig" with {
-  var: "foo"
+  'foo': 'bar'
 } %}
+
+{% embed "./path/to/template.html.twig" %}
+  ...
+{% endembed %}
+
+{% embed "./path/to/template.html.twig" with {
+  'foo': 'bar'
+} %}
+  ...
+{% endembed %}
 ```

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,27 @@
+# Conventions
+
+## Whitespaces
+
+[More information](./decisions/001-strip-whitespaces.md)
+
+## Includes and embeds should always use the `only` keyword
+
+The `only` keyword disables access to the context, thus preventing leaks.
+
+<!-- prettier-ignore -->
+```html
+<!-- Do -->
+{% include "./path/to/template.html.twig" only %}
+
+{% include "./path/to/template.html.twig" with {
+  var: "foo"
+} only %}
+
+
+<!-- Don't -->
+{% include "./path/to/template.html.twig" %}
+
+{% include "./path/to/template.html.twig" with {
+  var: "foo"
+} %}
+```

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -9,7 +9,7 @@
 The `only` keyword disables access to the context, thus preventing leaks.
 
 <!-- prettier-ignore -->
-```html
+```twig
 <!-- Do -->
 {% include "./path/to/template.html.twig" only %}
 

--- a/docs/decisions/001-strip-whitespaces.md
+++ b/docs/decisions/001-strip-whitespaces.md
@@ -162,7 +162,7 @@ Here are more details about the different recommendations of point 1.
 Wrap your template within `{% spaceless %}...{% endspaceless %}`:
 
 <!-- prettier-ignore -->
-```html
+```twig
 {% spaceless %}
 
 {#
@@ -195,7 +195,7 @@ You can trim leading and trailing whitespaces with `-` (dash) in the following w
 
 It makes sense to use it when you print content between 2 tags:
 
-```html
+```twig
 <!-- Do -->
 </span>
   {{- my_var -}}
@@ -209,7 +209,7 @@ It makes sense to use it when you print content between 2 tags:
 
 or inside a tag:
 
-```html
+```twig
 <!-- Do -->
 <span>
   {{- my_var -}}
@@ -223,7 +223,7 @@ or inside a tag:
 
 But it doesn’t make sense in attributes,
 
-```html
+```twig
 <!-- Do -->
 <span {{ my_var }} />
 
@@ -277,7 +277,7 @@ We could also try to get the output of the Twig template to be on a single line 
 Concretely, it would mean replacing:
 
 <!-- prettier-ignore -->
-```html
+```twig
 <select
   id="{{ _id }}"
   name="{{ _name }}"
@@ -290,7 +290,7 @@ Concretely, it would mean replacing:
 With something like:
 
 <!-- prettier-ignore -->
-```html
+```twig
 <select
   {{- ' id="#{_id}"' -}}
   {{- ' name="#{_name}"' -}}

--- a/docs/decisions/001-strip-whitespaces.md
+++ b/docs/decisions/001-strip-whitespaces.md
@@ -233,7 +233,7 @@ But it doesn’t make sense in attributes,
 
 or when there’s no space around:
 
-```html
+```twig
 <!-- Do -->
 </span>{{ my_var }}<span>
 
@@ -241,7 +241,7 @@ or when there’s no space around:
 </span>{{- my_var -}}<span>
 ```
 
-```html
+```twig
 <!-- Do -->
 <span>{{ my_var }}</span>
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-jest": "24.1.0",
     "babel-loader": "8.0.5",
     "clipboard": "2.0.4",
+    "deepmerge": "3.2.0",
     "eslint": "5.14.1",
     "eslint-config-airbnb": "17.1.0",
     "eslint-config-prettier": "4.0.0",

--- a/src/ec/packages/ec-component-button/__snapshots__/button.test.js.snap
+++ b/src/ec/packages/ec-component-button/__snapshots__/button.test.js.snap
@@ -27,6 +27,62 @@ exports[`EC - Button CTA button - icon after renders correctly 1`] = `
 </button>
 `;
 
+exports[`EC - Button CTA button - icon after renders correctly with extra attributes 1`] = `
+<button
+  class="ecl-button ecl-button--call"
+  data-test="data-test-value"
+  data-test-1="data-test-value-1"
+  type="submit"
+>
+  <span
+    class="ecl-button__container"
+  >
+    <span
+      class="ecl-button__label"
+      data-ecl-label=""
+    >
+      CTA Button with icon
+    </span>
+    <svg
+      aria-hidden="true"
+      class="ecl-icon ecl-icon--fluid ecl-button__icon ecl-button__icon--after"
+      focusable="false"
+    >
+      <use
+        xlink:href="static/icons.svg#ui--corner-arrow"
+      />
+    </svg>
+  </span>
+</button>
+`;
+
+exports[`EC - Button CTA button - icon after renders correctly with extra class names 1`] = `
+<button
+  class="ecl-button ecl-button--call custom-button custom-button--test"
+  type="submit"
+>
+  <span
+    class="ecl-button__container"
+  >
+    <span
+      class="ecl-button__label"
+      data-ecl-label=""
+    >
+      CTA Button with icon
+    </span>
+    <svg
+      aria-hidden="true"
+      class="ecl-icon ecl-icon--fluid ecl-button__icon ecl-button__icon--after"
+      focusable="false"
+    >
+      <use
+        xlink:href="static/icons.svg#ui--corner-arrow"
+      />
+    </svg>
+  </span>
+</button>
+`;
+
 exports[`EC - Button CTA button - icon before renders correctly 1`] = `
 <button
   class="ecl-button ecl-button--call"

--- a/src/ec/packages/ec-component-button/button.test.js
+++ b/src/ec/packages/ec-component-button/button.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { renderTwigFileAsNode } from '@ecl-twig/test-utils';
+import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 // Import data for tests
 import dataPrimary from '@ecl/ec-specs-button/demo/data--primary';
@@ -72,21 +72,44 @@ describe('EC - Button', () => {
   });
 
   describe('CTA button - icon after', () => {
+    const buttonData = {
+      label: 'CTA Button with icon',
+      variant: 'call',
+      icon: {
+        path: 'static/icons.svg',
+        type: 'ui',
+        name: 'corner-arrow',
+        size: 'fluid',
+      },
+    };
+
     test('renders correctly', () => {
       expect.assertions(1);
 
-      const buttonData = {
-        label: 'CTA Button with icon',
-        variant: 'call',
-        icon: {
-          path: 'static/icons.svg',
-          type: 'ui',
-          name: 'corner-arrow',
-          size: 'fluid',
-        },
-      };
-
       return expect(render(buttonData)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra class names', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(buttonData, {
+        extra_classes: 'custom-button custom-button--test',
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra attributes', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(buttonData, {
+        extra_attributes: [
+          { name: 'data-test', value: 'data-test-value' },
+          { name: 'data-test-1', value: 'data-test-value-1' },
+        ],
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
     });
   });
 });

--- a/src/ec/packages/ec-component-file/__snapshots__/file.test.js.snap
+++ b/src/ec/packages/ec-component-file/__snapshots__/file.test.js.snap
@@ -50,7 +50,6 @@ exports[`EC - File With translation renders correctly 1`] = `
       <svg
         aria-hidden="true"
         class="ecl-icon ecl-icon--fluid ecl-link__icon"
-        download=""
         focusable="false"
       >
         <use
@@ -124,9 +123,7 @@ exports[`EC - File With translation renders correctly 1`] = `
           <svg
             aria-hidden="true"
             class="ecl-icon ecl-icon--fluid ecl-link__icon"
-            download=""
             focusable="false"
-            hreflang=""
           >
             <use
               xlink:href="/static/icons.svg#ui--download"
@@ -166,9 +163,7 @@ exports[`EC - File With translation renders correctly 1`] = `
           <svg
             aria-hidden="true"
             class="ecl-icon ecl-icon--fluid ecl-link__icon"
-            download=""
             focusable="false"
-            hreflang=""
           >
             <use
               xlink:href="/static/icons.svg#ui--download"
@@ -208,9 +203,7 @@ exports[`EC - File With translation renders correctly 1`] = `
           <svg
             aria-hidden="true"
             class="ecl-icon ecl-icon--fluid ecl-link__icon"
-            download=""
             focusable="false"
-            hreflang=""
           >
             <use
               xlink:href="/static/icons.svg#ui--download"
@@ -278,7 +271,6 @@ exports[`EC - File Without translation renders correctly 1`] = `
       <svg
         aria-hidden="true"
         class="ecl-icon ecl-icon--fluid ecl-link__icon"
-        download=""
         focusable="false"
       >
         <use

--- a/src/ec/packages/ec-component-icon/icon.html.twig
+++ b/src/ec/packages/ec-component-icon/icon.html.twig
@@ -30,7 +30,7 @@
   size: 'm',
   transform: '',
   color: ''
-}|merge(icon) %}
+}|merge(icon|default({})) %}
 
 {% set _css_class = ['ecl-icon'] %}
 

--- a/src/ec/packages/ec-component-link/__snapshots__/link.test.js.snap
+++ b/src/ec/packages/ec-component-link/__snapshots__/link.test.js.snap
@@ -41,6 +41,54 @@ exports[`EC - Link With icon after renders correctly 1`] = `
 </a>
 `;
 
+exports[`EC - Link With icon after renders correctly with extra attributes 1`] = `
+<a
+  class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after"
+  data-test="data-test-value"
+  data-test-1="data-test-value-1"
+  href="/path"
+>
+  <span
+    class="ecl-link__label"
+  >
+    Standalone link with icon
+  </span>
+   
+  <svg
+    aria-hidden="true"
+    class="ecl-icon ecl-icon--fluid ecl-link__icon"
+    focusable="false"
+  >
+    <use
+      xlink:href="static/icons.svg#ui--external"
+    />
+  </svg>
+</a>
+`;
+
+exports[`EC - Link With icon after renders correctly with extra class names 1`] = `
+<a
+  class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after custom-link custom-link--test"
+  href="/path"
+>
+  <span
+    class="ecl-link__label"
+  >
+    Standalone link with icon
+  </span>
+   
+  <svg
+    aria-hidden="true"
+    class="ecl-icon ecl-icon--fluid ecl-link__icon"
+    focusable="false"
+  >
+    <use
+      xlink:href="static/icons.svg#ui--external"
+    />
+  </svg>
+</a>
+`;
+
 exports[`EC - Link With icon before renders correctly 1`] = `
 <a
   class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-before"

--- a/src/ec/packages/ec-component-link/link.html.twig
+++ b/src/ec/packages/ec-component-link/link.html.twig
@@ -70,13 +70,19 @@
 <a href="{{ _link.path }}" class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {%- if _icon.name is not empty %}
     {% if _link.icon_position == 'before' %}
-      {% include '../ec-component-icon/icon.html.twig' with icon|merge({extra_classes: 'ecl-link__icon'}) %}
+      {% include '../ec-component-icon/icon.html.twig' with {
+        icon: _icon,
+        extra_classes: 'ecl-link__icon'
+      } only %}
       {{- '&nbsp;' }}
     {%- endif -%}
     <span class="ecl-link__label">{{ _link.label }}</span>
     {%- if _link.icon_position == 'after' %}
       {{- '&nbsp;' }}
-      {%- include '../ec-component-icon/icon.html.twig' with icon|merge({extra_classes: 'ecl-link__icon'}) %}
+      {%- include '../ec-component-icon/icon.html.twig' with {
+        icon: _icon,
+        extra_classes: 'ecl-link__icon'
+      } only %}
     {% endif %}
   {% else %}
     {{- _link.label }}

--- a/src/ec/packages/ec-component-link/link.test.js
+++ b/src/ec/packages/ec-component-link/link.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { renderTwigFileAsNode } from '@ecl-twig/test-utils';
+import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 describe('EC - Link', () => {
   const template = path.resolve(__dirname, './link.html.twig');
@@ -17,10 +17,14 @@ describe('EC - Link', () => {
     test('renders correctly', () => {
       expect.assertions(1);
 
-      defaultDataStructure.link.type = 'default';
-      defaultDataStructure.link.label = 'Default link';
+      const options = merge(defaultDataStructure, {
+        link: {
+          type: 'default',
+          label: 'Default link',
+        },
+      });
 
-      return expect(render(defaultDataStructure)).resolves.toMatchSnapshot();
+      return expect(render(options)).resolves.toMatchSnapshot();
     });
   });
 
@@ -28,10 +32,14 @@ describe('EC - Link', () => {
     test('renders correctly', () => {
       expect.assertions(1);
 
-      defaultDataStructure.link.type = 'standalone';
-      defaultDataStructure.link.label = 'Standalone link';
+      const options = merge(defaultDataStructure, {
+        link: {
+          type: 'standalone',
+          label: 'Standalone link',
+        },
+      });
 
-      return expect(render(defaultDataStructure)).resolves.toMatchSnapshot();
+      return expect(render(options)).resolves.toMatchSnapshot();
     });
   });
 
@@ -39,35 +47,65 @@ describe('EC - Link', () => {
     test('renders correctly', () => {
       expect.assertions(1);
 
-      defaultDataStructure.link.type = 'standalone';
-      defaultDataStructure.link.label = 'Standalone link with icon';
-      defaultDataStructure.link.icon_position = 'before';
-      defaultDataStructure.icon = {
-        type: 'ui',
-        name: 'external',
-        size: 'fluid',
-        path: defaultIconPath,
-      };
+      const options = merge(defaultDataStructure, {
+        link: {
+          type: 'standalone',
+          label: 'Standalone link with icon',
+          icon_position: 'before',
+        },
+        icon: {
+          type: 'ui',
+          name: 'external',
+          size: 'fluid',
+          path: defaultIconPath,
+        },
+      });
 
-      return expect(render(defaultDataStructure)).resolves.toMatchSnapshot();
+      return expect(render(options)).resolves.toMatchSnapshot();
     });
   });
 
   describe('With icon after', () => {
-    test('renders correctly', () => {
-      expect.assertions(1);
-
-      defaultDataStructure.link.type = 'standalone';
-      defaultDataStructure.link.label = 'Standalone link with icon';
-      defaultDataStructure.link.icon_position = 'after';
-      defaultDataStructure.icon = {
+    const options = merge(defaultDataStructure, {
+      link: {
+        type: 'standalone',
+        label: 'Standalone link with icon',
+        icon_position: 'after',
+      },
+      icon: {
         type: 'ui',
         name: 'external',
         size: 'fluid',
         path: defaultIconPath,
-      };
+      },
+    });
 
-      return expect(render(defaultDataStructure)).resolves.toMatchSnapshot();
+    test('renders correctly', () => {
+      expect.assertions(1);
+      return expect(render(options)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra class names', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(options, {
+        extra_classes: 'custom-link custom-link--test',
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra attributes', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(options, {
+        extra_attributes: [
+          { name: 'data-test', value: 'data-test-value' },
+          { name: 'data-test-1', value: 'data-test-value-1' },
+        ],
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
     });
   });
 });

--- a/src/ec/packages/ec-component-select/__snapshots__/select.test.js.snap
+++ b/src/ec/packages/ec-component-select/__snapshots__/select.test.js.snap
@@ -203,3 +203,147 @@ exports[`EC - Select With error renders correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`EC - Select With error renders correctly with extra attributes 1`] = `
+<div
+  class="ecl-form-group ecl-form-group--select"
+>
+  <label
+    class="ecl-form-label ecl-form-label--invalid"
+    for="example-id"
+  >
+    Select a country
+  </label>
+  <div
+    class="ecl-select__container"
+  >
+    <select
+      class="ecl-select ecl-select--invalid"
+      data-test="data-test-value"
+      data-test-1="data-test-value-1"
+      id="example-id"
+      name="example-name"
+    >
+      <option
+        value="1"
+      >
+        Belgium
+      </option>
+      <option
+        value="2"
+      >
+        France
+      </option>
+      <option
+        value="3"
+      >
+        Luxembourg
+      </option>
+      <option
+        value="4"
+      >
+        Germany
+      </option>
+      <option
+        value="5"
+      >
+        Bulgaria
+      </option>
+    </select>
+    <div
+      class="ecl-select__icon"
+    >
+      <svg
+        aria-hidden="true"
+        class="ecl-icon ecl-icon--s ecl-icon--rotate-180 ecl-select__icon-shape"
+        focusable="false"
+      >
+        <use
+          xlink:href="path-to-icons-file.svg#ui--corner-arrow"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    class="ecl-feedback-message"
+  >
+    Error message
+  </div>
+  <div
+    class="ecl-help-block"
+  >
+    Help message
+  </div>
+</div>
+`;
+
+exports[`EC - Select With error renders correctly with extra class names 1`] = `
+<div
+  class="ecl-form-group ecl-form-group--select"
+>
+  <label
+    class="ecl-form-label ecl-form-label--invalid"
+    for="example-id"
+  >
+    Select a country
+  </label>
+  <div
+    class="ecl-select__container"
+  >
+    <select
+      class="ecl-select ecl-select--invalid custom-select custom-select--test"
+      id="example-id"
+      name="example-name"
+    >
+      <option
+        value="1"
+      >
+        Belgium
+      </option>
+      <option
+        value="2"
+      >
+        France
+      </option>
+      <option
+        value="3"
+      >
+        Luxembourg
+      </option>
+      <option
+        value="4"
+      >
+        Germany
+      </option>
+      <option
+        value="5"
+      >
+        Bulgaria
+      </option>
+    </select>
+    <div
+      class="ecl-select__icon"
+    >
+      <svg
+        aria-hidden="true"
+        class="ecl-icon ecl-icon--s ecl-icon--rotate-180 ecl-select__icon-shape"
+        focusable="false"
+      >
+        <use
+          xlink:href="path-to-icons-file.svg#ui--corner-arrow"
+        />
+      </svg>
+    </div>
+  </div>
+  <div
+    class="ecl-feedback-message"
+  >
+    Error message
+  </div>
+  <div
+    class="ecl-help-block"
+  >
+    Help message
+  </div>
+</div>
+`;

--- a/src/ec/packages/ec-component-select/select.html.twig
+++ b/src/ec/packages/ec-component-select/select.html.twig
@@ -92,7 +92,7 @@
           transform: "rotate-180"
         },
         extra_classes: "ecl-select__icon-shape"
-      } %}
+      } only %}
     </div>
   </div>
 

--- a/src/ec/packages/ec-component-select/select.test.js
+++ b/src/ec/packages/ec-component-select/select.test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { renderTwigFileAsNode } from '@ecl-twig/test-utils';
+import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import specData from '@ecl/ec-specs-select/demo/data';
 
@@ -43,21 +43,44 @@ describe('EC - Select', () => {
   });
 
   describe('With error', () => {
+    const options = {
+      invalid: true,
+      invalid_text: 'Error message',
+      label: specData.label,
+      options: specData.options,
+      helper_text: 'Help message',
+      icon_path: 'path-to-icons-file.svg',
+      id: 'example-id',
+      name: 'example-name',
+    };
+
     test('renders correctly', () => {
       expect.assertions(1);
 
-      return expect(
-        render({
-          invalid: true,
-          invalid_text: 'Error message',
-          label: specData.label,
-          options: specData.options,
-          helper_text: 'Help message',
-          icon_path: 'path-to-icons-file.svg',
-          id: 'example-id',
-          name: 'example-name',
-        })
-      ).resolves.toMatchSnapshot();
+      return expect(render(options)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra class names', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(options, {
+        extra_classes: 'custom-select custom-select--test',
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
+    });
+
+    test('renders correctly with extra attributes', () => {
+      expect.assertions(1);
+
+      const optionsWithExtraClasses = merge(options, {
+        extra_attributes: [
+          { name: 'data-test', value: 'data-test-value' },
+          { name: 'data-test-1', value: 'data-test-value-1' },
+        ],
+      });
+
+      return expect(render(optionsWithExtraClasses)).resolves.toMatchSnapshot();
     });
   });
 });

--- a/utils/test-utils/index.js
+++ b/utils/test-utils/index.js
@@ -1,5 +1,6 @@
 const Twig = require('twig');
 const { format } = require('prettier');
+const merge = require('deepmerge');
 
 const renderTwigFile = (file, options, cb) =>
   Twig.renderFile(file, options, (err, html) =>
@@ -19,6 +20,7 @@ const renderTwigFileAsNode = (file, options) =>
   );
 
 module.exports = {
+  merge,
   renderTwigFile,
   renderTwigFileAsNode,
 };


### PR DESCRIPTION
Without the `only` keyword on includes and embeds, the context leaks and since we use the same `extra_classes` and `extra_attributes` everywhere, all the templates in the cascade can read them!

TODO:
- [x] write more tests containing extra_attributes, extra_classes