### PR TITLE
fix: change the way we load sub-components - INNO-1550

### DIFF
--- a/src/ec/packages/ec-component-gallery/gallery.html.twig
+++ b/src/ec/packages/ec-component-gallery/gallery.html.twig
@@ -48,7 +48,7 @@
 <section class="{{ _css_class }}"{{ _extra_attributes }} data-ecl-gallery>
   <ul class="ecl-gallery__list">
     {% for _item in _items %}
-      {% include './gallery-item.html.twig' with {
+      {% include '../ec-component-gallery/gallery-item.html.twig' with {
         item: _item,
       } only %}
     {% endfor %}
@@ -58,7 +58,7 @@
   {% if _items[_selected_item_id] is not empty %}
     {% set _selected_item = _items[_selected_item_id] %}
   {% endif %}
-  {% include './gallery-overlay.html.twig' with {
+  {% include '../ec-component-gallery/gallery-overlay.html.twig' with {
     overlay: _overlay,
     item: _selected_item
   } only %}

--- a/src/ec/packages/ec-component-language-list/language-list-overlay.html.twig
+++ b/src/ec/packages/ec-component-language-list/language-list-overlay.html.twig
@@ -72,7 +72,7 @@
       </div>
     </div>
 
-    {% include './language-list.html.twig' with {
+    {% include '../ec-component-language-list/language-list.html.twig' with {
       items: _items,
       overlay: true,
       icon_path: _icon_path

--- a/src/ec/packages/ec-component-language-list/language-list-splash.html.twig
+++ b/src/ec/packages/ec-component-language-list/language-list-splash.html.twig
@@ -46,7 +46,7 @@
   </header>
 
   <div class="ecl-language-list__container ecl-container">
-    {% include './language-list.html.twig' with {
+    {% include '../ec-component-language-list/language-list.html.twig' with {
       items: _items,
       icon_path: _icon_path
     } only %}

--- a/src/ec/packages/ec-component-language-list/language-list.html.twig
+++ b/src/ec/packages/ec-component-language-list/language-list.html.twig
@@ -29,7 +29,7 @@
     <ul class="ecl-language-list__list">
       {% for _item in _column1 %}
         <li class="ecl-language-list__item{{ _item.active ? ' ecl-language-list__item--is-active' : '' }}">
-          {% include './language-list-item.html.twig' with {
+          {% include '../ec-component-language-list/language-list-item.html.twig' with {
             item: _item,
             overlay: _overlay,
             icon_path: _icon_path
@@ -42,7 +42,7 @@
     <ul class="ecl-language-list__list">
       {% for _item in _column2 %}
         <li class="ecl-language-list__item{{ _item.active ? ' ecl-language-list__item--is-active' : '' }}">
-          {% include './language-list-item.html.twig' with {
+          {% include '../ec-component-language-list/language-list-item.html.twig' with {
             item: _item,
             overlay: _overlay,
             icon_path: _icon_path

--- a/src/ec/packages/ec-component-radio/radio-group.html.twig
+++ b/src/ec/packages/ec-component-radio/radio-group.html.twig
@@ -59,9 +59,9 @@
 
 {# Print the result #}
 
-<div 
-  class="{{ _css_class }}" 
-  role="radiogroup" 
+<div
+  class="{{ _css_class }}"
+  role="radiogroup"
   aria-labelledby="{{ label_id }}"
   {{ _helper_id is not empty ? "aria-describedby=\"" ~ _helper_id ~ "\""}}
   {{ _extra_attributes|raw }}
@@ -77,7 +77,7 @@
   {% endif %}
 
   {% if _helper_text is not empty %}
-    <p 
+    <p
       class="ecl-radio__help ecl-help-block"
       {{ _helper_id is not empty ? "id=\"" ~ _helper_id ~ "\""}}
     >
@@ -92,7 +92,7 @@
   {% endif %}
 
   {%- for _item in _items %}
-    {% include './radio-button.html.twig' with _item|merge({
+    {% include '../ec-component-radio/radio-button.html.twig' with _item|merge({
       name: _name,
     }) only %}
   {% endfor -%}


### PR DESCRIPTION
# PR description

Sorry for the confusion, i created the branch and named the commit using the DTTSB label instead of INNO.. :)

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
