### PR TITLE
feat(file): add download link per translation - INNO-1581

### DIFF
--- a/src/ec/packages/ec-component-file/__snapshots__/file.test.js.snap
+++ b/src/ec/packages/ec-component-file/__snapshots__/file.test.js.snap
@@ -111,7 +111,7 @@ exports[`EC - File With translation renders correctly 1`] = `
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#bg"
           hreflang="bg"
         >
           <span
@@ -152,7 +152,7 @@ exports[`EC - File With translation renders correctly 1`] = `
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#es"
           hreflang="es"
         >
           <span
@@ -193,7 +193,7 @@ exports[`EC - File With translation renders correctly 1`] = `
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#fr"
           hreflang="fr"
         >
           <span
@@ -336,7 +336,7 @@ exports[`EC - File With translation renders correctly with extra attributes 1`] 
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#bg"
           hreflang="bg"
         >
           <span
@@ -377,7 +377,7 @@ exports[`EC - File With translation renders correctly with extra attributes 1`] 
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#es"
           hreflang="es"
         >
           <span
@@ -418,7 +418,7 @@ exports[`EC - File With translation renders correctly with extra attributes 1`] 
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#fr"
           hreflang="fr"
         >
           <span
@@ -559,7 +559,7 @@ exports[`EC - File With translation renders correctly with extra class names 1`]
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#bg"
           hreflang="bg"
         >
           <span
@@ -600,7 +600,7 @@ exports[`EC - File With translation renders correctly with extra class names 1`]
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#es"
           hreflang="es"
         >
           <span
@@ -641,7 +641,7 @@ exports[`EC - File With translation renders correctly with extra class names 1`]
         <a
           class="ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-after ecl-file__translation-download"
           download=""
-          href="/example"
+          href="/example#fr"
           hreflang="fr"
         >
           <span

--- a/src/ec/packages/ec-component-file/demo/data.js
+++ b/src/ec/packages/ec-component-file/demo/data.js
@@ -38,29 +38,49 @@ export const dataWithTranslation = {
   icon: formatIcon(specDataWithTranslation.icon),
   download: formatLink(specDataWithTranslation.download),
   translation: {
-    toggle: specDataWithTranslation.translation.toggle,
+    toggle: {
+      ...specDataWithTranslation.translation.toggle,
+      icon: {
+        path: '/static/icons.svg',
+      },
+    },
     description: specDataWithTranslation.translation.description,
     items: [
       {
         ...specDataWithTranslation.translation.items[0],
-        download: formatLink({
-          label: 'Download',
-          href: '/example#bg',
-        }),
+        download: {
+          link: {
+            label: 'Download',
+            path: '/example#bg',
+          },
+          icon: {
+            path: '/static/icons.svg',
+          },
+        },
       },
       {
         ...specDataWithTranslation.translation.items[1],
-        download: formatLink({
-          label: 'Download',
-          href: '/example#es',
-        }),
+        download: {
+          link: {
+            label: 'Download',
+            path: '/example#es',
+          },
+          icon: {
+            path: '/static/icons.svg',
+          },
+        },
       },
       {
         ...specDataWithTranslation.translation.items[2],
-        download: formatLink({
-          label: 'Download',
-          href: '/example#fr',
-        }),
+        download: {
+          link: {
+            label: 'Download',
+            path: '/example#fr',
+          },
+          icon: {
+            path: '/static/icons.svg',
+          },
+        },
       },
     ],
   },

--- a/src/ec/packages/ec-component-file/demo/data.js
+++ b/src/ec/packages/ec-component-file/demo/data.js
@@ -2,12 +2,10 @@
 import specDataWithTranslation from '@ecl/ec-specs-file/demo/data--with-translation';
 import specDataWithoutTranslation from '@ecl/ec-specs-file/demo/data--without-translation';
 
-const iconPath = '/static/icons.svg';
-
 function formatIcon(i) {
   const [type, name] = i.shape.split('--');
   const icon = {
-    path: iconPath,
+    path: '/static/icons.svg',
     type,
     name,
     size: i.size,
@@ -34,7 +32,6 @@ function formatLink(l) {
 }
 
 export const dataWithTranslation = {
-  icon_path: iconPath,
   title: specDataWithTranslation.title,
   language: specDataWithTranslation.language,
   meta: specDataWithTranslation.meta,
@@ -70,7 +67,6 @@ export const dataWithTranslation = {
 };
 
 export const dataWithoutTranslation = {
-  icon_path: iconPath,
   title: specDataWithoutTranslation.title,
   language: specDataWithoutTranslation.language,
   meta: specDataWithoutTranslation.meta,

--- a/src/ec/packages/ec-component-file/demo/data.js
+++ b/src/ec/packages/ec-component-file/demo/data.js
@@ -2,10 +2,12 @@
 import specDataWithTranslation from '@ecl/ec-specs-file/demo/data--with-translation';
 import specDataWithoutTranslation from '@ecl/ec-specs-file/demo/data--without-translation';
 
+const iconPath = '/static/icons.svg';
+
 function formatIcon(i) {
   const [type, name] = i.shape.split('--');
   const icon = {
-    path: '/static/icons.svg',
+    path: iconPath,
     type,
     name,
     size: i.size,
@@ -13,15 +15,6 @@ function formatIcon(i) {
   };
 
   return icon;
-}
-
-function formatButton(b) {
-  const button = {
-    label: b.label,
-    icon: formatIcon(b.icon),
-  };
-
-  return button;
 }
 
 function formatLink(l) {
@@ -41,19 +34,43 @@ function formatLink(l) {
 }
 
 export const dataWithTranslation = {
+  icon_path: iconPath,
   title: specDataWithTranslation.title,
   language: specDataWithTranslation.language,
   meta: specDataWithTranslation.meta,
   icon: formatIcon(specDataWithTranslation.icon),
   download: formatLink(specDataWithTranslation.download),
   translation: {
-    toggle: formatButton(specDataWithTranslation.translation.toggle),
+    toggle: specDataWithTranslation.translation.toggle,
     description: specDataWithTranslation.translation.description,
-    items: specDataWithTranslation.translation.items,
+    items: [
+      {
+        ...specDataWithTranslation.translation.items[0],
+        download: formatLink({
+          label: 'Download',
+          href: '/example#bg',
+        }),
+      },
+      {
+        ...specDataWithTranslation.translation.items[1],
+        download: formatLink({
+          label: 'Download',
+          href: '/example#es',
+        }),
+      },
+      {
+        ...specDataWithTranslation.translation.items[2],
+        download: formatLink({
+          label: 'Download',
+          href: '/example#fr',
+        }),
+      },
+    ],
   },
 };
 
 export const dataWithoutTranslation = {
+  icon_path: iconPath,
   title: specDataWithoutTranslation.title,
   language: specDataWithoutTranslation.language,
   meta: specDataWithoutTranslation.meta,

--- a/src/ec/packages/ec-component-file/docs/file.md
+++ b/src/ec/packages/ec-component-file/docs/file.md
@@ -9,6 +9,7 @@ npm install --save @ecl-twig/ec-component-file
 ## Parameters
 
 - "icon" (object) (default: {}): object of type Icon; file type
+- "icon_path" (string) (default: ''): path to the icon file
 - "title" (string) (default: '')
 - "language" (string) (default: '')
 - "meta" (string) (default: '')
@@ -19,6 +20,7 @@ npm install --save @ecl-twig/ec-component-file
     - "title" (string) (default: '')
     - "meta" (string) (default: '')
     - "lang" (string) (default: '')
+    - "download" (object) (default to the parent download property) object of type Link
   - "description (string) (default:'')
 - "extra_classes" (optional) (string) (default: '')
 - "extra_attributes" (optional) (array) (default: [])
@@ -33,6 +35,7 @@ npm install --save @ecl-twig/ec-component-file
   title: 'State of the Union 2018 brochure', 
   language: 'English', 
   meta: '(16.2 MB - PDF)', 
+  icon_path: 'path/to/icons.svg', 
   icon: { 
     type: 'general', 
     name: 'copy', 

--- a/src/ec/packages/ec-component-file/docs/file.md
+++ b/src/ec/packages/ec-component-file/docs/file.md
@@ -9,7 +9,6 @@ npm install --save @ecl-twig/ec-component-file
 ## Parameters
 
 - "icon" (object) (default: {}): object of type Icon; file type
-- "icon_path" (string) (default: ''): path to the icon file
 - "title" (string) (default: '')
 - "language" (string) (default: '')
 - "meta" (string) (default: '')

--- a/src/ec/packages/ec-component-file/file.html.twig
+++ b/src/ec/packages/ec-component-file/file.html.twig
@@ -2,6 +2,7 @@
 {#
   Parameters:
   - "icon" (object) (default: {}): object of type Icon; file type
+  - "icon_path" (string) (default: ''): path to the icon file
   - "title" (string) (default: '')
   - "language" (string) (default: '')
   - "meta" (string) (default: '')
@@ -12,6 +13,7 @@
       - "title" (string) (default: '')
       - "meta" (string) (default: '')
       - "lang" (string) (default: '')
+      - "download" (object) (default to the parent download property) object of type Link
     - "description (string) (default:'')
   - "extra_classes" (optional) (string) (default: '')
   - "extra_attributes" (optional) (array) (default: [])
@@ -22,6 +24,7 @@
 {# Internal properties #}
 
 {% set _icon = icon|default({}) %}
+{% set _icon_path = icon_path|default(_icon.path|default('')) %}
 {% set _title = title|default('') %}
 {% set _language = language|default('') %}
 {% set _meta = meta|default('') %}
@@ -63,6 +66,12 @@
         type: 'standalone',
         icon_position: 'after',
       }),
+      icon: {
+        path: _icon_path,
+        type: 'ui',
+        name: 'download',
+        size: 'fluid'
+      },
       extra_classes: 'ecl-file__download',
       extra_attributes: [{ name: 'download' }]
     }) only %}
@@ -73,6 +82,13 @@
       {% include '../ec-component-button/button.html.twig' with _translation.toggle|merge({
         variant: 'ghost',
         type: 'button',
+        icon: {
+          path: _icon_path,
+          type: 'ui',
+          name: 'corner-arrow',
+          size: 'fluid',
+          transform: 'rotate-180'
+        },
         extra_classes: 'ecl-file__translation-toggle',
         extra_attributes: [{ name: 'data-ecl-file-translation-toggle' }]
       }) only %}
@@ -90,10 +106,16 @@
               <div class="ecl-file__translation-meta">{{ _item.meta }}</div>
             </div>
             {% include '../ec-component-link/link.html.twig' with _download|merge({
-              link: _download.link|default({})|merge({
+              link: _item.download.link|default(_download.link|default({}))|merge({
                 type: 'standalone',
                 icon_position: 'after'
               }),
+              icon: {
+                path: _icon_path,
+                type: 'ui',
+                name: 'download',
+                size: 'fluid'
+              },
               extra_classes: 'ecl-file__translation-download',
               extra_attributes: [
                 { name: 'download' },

--- a/src/ec/packages/ec-component-file/file.html.twig
+++ b/src/ec/packages/ec-component-file/file.html.twig
@@ -2,7 +2,6 @@
 {#
   Parameters:
   - "icon" (object) (default: {}): object of type Icon; file type
-  - "icon_path" (string) (default: ''): path to the icon file
   - "title" (string) (default: '')
   - "language" (string) (default: '')
   - "meta" (string) (default: '')
@@ -24,7 +23,6 @@
 {# Internal properties #}
 
 {% set _icon = icon|default({}) %}
-{% set _icon_path = icon_path|default(_icon.path|default('')) %}
 {% set _title = title|default('') %}
 {% set _language = language|default('') %}
 {% set _meta = meta|default('') %}
@@ -66,12 +64,11 @@
         type: 'standalone',
         icon_position: 'after',
       }),
-      icon: {
-        path: _icon_path,
+      icon: _download.icon|default({})|merge({
         type: 'ui',
         name: 'download',
         size: 'fluid'
-      },
+      }),
       extra_classes: 'ecl-file__download',
       extra_attributes: [{ name: 'download' }]
     }) only %}
@@ -82,13 +79,12 @@
       {% include '../ec-component-button/button.html.twig' with _translation.toggle|merge({
         variant: 'ghost',
         type: 'button',
-        icon: {
-          path: _icon_path,
+        icon: _translation.toggle.icon|default({})|merge({
           type: 'ui',
           name: 'corner-arrow',
           size: 'fluid',
           transform: 'rotate-180'
-        },
+        }),
         extra_classes: 'ecl-file__translation-toggle',
         extra_attributes: [{ name: 'data-ecl-file-translation-toggle' }]
       }) only %}
@@ -110,12 +106,11 @@
                 type: 'standalone',
                 icon_position: 'after'
               }),
-              icon: {
-                path: _icon_path,
+              icon: _item.download.icon|default(_download.icon|default({}))|merge({
                 type: 'ui',
                 name: 'download',
                 size: 'fluid'
-              },
+              }),
               extra_classes: 'ecl-file__translation-download',
               extra_attributes: [
                 { name: 'download' },

--- a/src/ec/packages/ec-component-file/file.story.js
+++ b/src/ec/packages/ec-component-file/file.story.js
@@ -11,10 +11,21 @@ import fileDocs from './docs/file.md';
 import file from './file.html.twig';
 
 // Add icon path
-dataWithTranslation.icon_path = defaultSprite;
 dataWithTranslation.icon.path = defaultSprite;
-dataWithoutTranslation.icon_path = defaultSprite;
+dataWithTranslation.download.icon.path = defaultSprite;
+dataWithTranslation.translation.toggle.icon.path = defaultSprite;
+dataWithTranslation.translation.items[0].download.icon = {
+  path: defaultSprite,
+};
+dataWithTranslation.translation.items[1].download.icon = {
+  path: defaultSprite,
+};
+dataWithTranslation.translation.items[2].download.icon = {
+  path: defaultSprite,
+};
+
 dataWithoutTranslation.icon.path = defaultSprite;
+dataWithoutTranslation.download.icon.path = defaultSprite;
 
 storiesOf('Components/File', module)
   .addDecorator(withKnobs)

--- a/src/ec/packages/ec-component-file/file.story.js
+++ b/src/ec/packages/ec-component-file/file.story.js
@@ -11,11 +11,10 @@ import fileDocs from './docs/file.md';
 import file from './file.html.twig';
 
 // Add icon path
+dataWithTranslation.icon_path = defaultSprite;
 dataWithTranslation.icon.path = defaultSprite;
-dataWithTranslation.download.icon.path = defaultSprite;
-dataWithTranslation.translation.toggle.icon.path = defaultSprite;
+dataWithoutTranslation.icon_path = defaultSprite;
 dataWithoutTranslation.icon.path = defaultSprite;
-dataWithoutTranslation.download.icon.path = defaultSprite;
 
 storiesOf('Components/File', module)
   .addDecorator(withKnobs)


### PR DESCRIPTION
New `download` property added to `translation.items`. This new property lets you define a custom label and href for each translation.

For convenience, there's also a new `icon_path` property which defaults to `icon.path` in order to avoid breaking changes. This new property is used for the icons that can not be changed (e.g. the download icons, the arrow icon)