### PR TITLE
fix: INNO-1696 Alt is not trigger on ec-component-card.

### DIFF
--- a/src/ec/packages/ec-component-card/__snapshots__/card.test.js.snap
+++ b/src/ec/packages/ec-component-card/__snapshots__/card.test.js.snap
@@ -8,7 +8,7 @@ exports[`EC - Card Default renders correctly 1`] = `
     class="ecl-card__header"
   >
     <div
-      alt="card image"
+      alt="Better regulation"
       class="ecl-card__image"
       style="background-image:url('https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg')"
     />
@@ -128,7 +128,7 @@ exports[`EC - Card Default renders correctly with extra attributes 1`] = `
     class="ecl-card__header"
   >
     <div
-      alt="card image"
+      alt="Better regulation"
       class="ecl-card__image"
       style="background-image:url('https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg')"
     />
@@ -246,7 +246,7 @@ exports[`EC - Card Default renders correctly with extra class names 1`] = `
     class="ecl-card__header"
   >
     <div
-      alt="card image"
+      alt="Better regulation"
       class="ecl-card__image"
       style="background-image:url('https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg')"
     />
@@ -363,6 +363,11 @@ exports[`EC - Card Tile renders correctly 1`] = `
   <header
     class="ecl-card__header"
   >
+    <div
+      alt=""
+      class="ecl-card__image"
+      style="background-image:url('')"
+    />
     <h1
       class="ecl-card__title"
     >
@@ -427,6 +432,11 @@ exports[`EC - Card Tile renders correctly with extra attributes 1`] = `
   <header
     class="ecl-card__header"
   >
+    <div
+      alt=""
+      class="ecl-card__image"
+      style="background-image:url('')"
+    />
     <h1
       class="ecl-card__title"
     >
@@ -489,6 +499,11 @@ exports[`EC - Card Tile renders correctly with extra class names 1`] = `
   <header
     class="ecl-card__header"
   >
+    <div
+      alt=""
+      class="ecl-card__image"
+      style="background-image:url('')"
+    />
     <h1
       class="ecl-card__title"
     >

--- a/src/ec/packages/ec-component-card/__snapshots__/card.test.js.snap
+++ b/src/ec/packages/ec-component-card/__snapshots__/card.test.js.snap
@@ -363,11 +363,6 @@ exports[`EC - Card Tile renders correctly 1`] = `
   <header
     class="ecl-card__header"
   >
-    <div
-      alt=""
-      class="ecl-card__image"
-      style="background-image:url('')"
-    />
     <h1
       class="ecl-card__title"
     >
@@ -432,11 +427,6 @@ exports[`EC - Card Tile renders correctly with extra attributes 1`] = `
   <header
     class="ecl-card__header"
   >
-    <div
-      alt=""
-      class="ecl-card__image"
-      style="background-image:url('')"
-    />
     <h1
       class="ecl-card__title"
     >
@@ -499,11 +489,6 @@ exports[`EC - Card Tile renders correctly with extra class names 1`] = `
   <header
     class="ecl-card__header"
   >
-    <div
-      alt=""
-      class="ecl-card__image"
-      style="background-image:url('')"
-    />
     <h1
       class="ecl-card__title"
     >

--- a/src/ec/packages/ec-component-card/card.html.twig
+++ b/src/ec/packages/ec-component-card/card.html.twig
@@ -77,7 +77,7 @@
 
 <article class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <header class="ecl-card__header">
-    {% if _card.image %}
+    {% if _card.image.src %}
       <div class="ecl-card__image" alt="{{ _card.image.alt }}" style="background-image:url('{{ _card.image.src }}')"></div>
     {% endif %}
     {% if _card.meta is not empty %}

--- a/src/ec/packages/ec-component-card/card.html.twig
+++ b/src/ec/packages/ec-component-card/card.html.twig
@@ -8,7 +8,7 @@
           description: '', (string) (default: ''): Description of card
           meta: [], (array) (default: []): Meta's for the Card
           title: {}, (associative array) (default: {}): Predefined structure compatible with Link component. If Card type is a 'tile', only label property is required.
-          image: '', (string) (default: ''): Url/path to background image (non required if Card type is a 'tile')
+          image: {}, (associative array) (default: ''): Url/path and alternate text of the background image (non required if Card type is a 'tile')
           tags: [], (array) (default: []): List of tags compatible with EC Tag component structure
           infos: [], (array) (default: []): format: [
             {
@@ -42,7 +42,7 @@
   description: '',
   meta: [],
   title: {},
-  image: '',
+  image: {},
   infos: [],
   tags: [],
   links: []
@@ -78,7 +78,7 @@
 <article class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <header class="ecl-card__header">
     {% if _card.image %}
-      <div class="ecl-card__image" alt="card image" style="background-image:url('{{ _card.image }}')"></div>
+      <div class="ecl-card__image" alt="{{ _card.image.alt }}" style="background-image:url('{{ _card.image.src }}')"></div>
     {% endif %}
     {% if _card.meta is not empty %}
       <div class="ecl-card__meta">{{ _card.meta|join(" | ") }}</div>

--- a/src/ec/packages/ec-component-card/card.story.js
+++ b/src/ec/packages/ec-component-card/card.story.js
@@ -66,10 +66,11 @@ storiesOf('Components/Card', module)
             'Transparently designing and evaluating evidence-based EU legislation, backed by citizens views.'
           ),
           meta: metaArray,
-          image: text(
-            'Image',
-            'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg'
-          ),
+          image: {
+            src:
+              'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+            alt: text('Image alternate text', 'Better regulation'),
+          },
           infos,
           tags,
         },

--- a/src/ec/packages/ec-component-card/card.story.js
+++ b/src/ec/packages/ec-component-card/card.story.js
@@ -68,10 +68,10 @@ storiesOf('Components/Card', module)
           meta: metaArray,
           image: {
             src: text(
-              'Image',
+              'Image path',
               'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg'
             ),
-            alt: text('Image alternate text', 'Better regulation'),
+            alt: text('Alternate text', 'Better regulation'),
           },
           infos,
           tags,

--- a/src/ec/packages/ec-component-card/card.story.js
+++ b/src/ec/packages/ec-component-card/card.story.js
@@ -67,8 +67,10 @@ storiesOf('Components/Card', module)
           ),
           meta: metaArray,
           image: {
-            src:
-              'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+            src: text(
+              'Image',
+              'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg'
+            ),
             alt: text('Image alternate text', 'Better regulation'),
           },
           infos,

--- a/src/ec/packages/ec-component-card/card.test.js
+++ b/src/ec/packages/ec-component-card/card.test.js
@@ -17,8 +17,11 @@ describe('EC - Card', () => {
         description:
           'Transparently designing and evaluating evidence-based EU legislation, backed by citizens views.',
         meta: ['Meta 1', 'Meta 2', 'Meta 3'],
-        image:
-          'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+        image: {
+          src:
+            'https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg',
+          alt: 'Better regulation',
+        },
         infos: [
           {
             label: '2018/10/22',

--- a/src/ec/packages/ec-component-card/docs/card.md
+++ b/src/ec/packages/ec-component-card/docs/card.md
@@ -15,7 +15,7 @@ npm install --save @ecl-twig/ec-component-card
   - "description" (string) (default: '') - Description of card
   - "meta" (array) (default: []) - Meta's for the Card
   - "title" (associative array) (default: {}) - Predefined structure compatible with Link component. If Card type is a 'tile', only label property is required.
-  - "image" (string) (default: '') - Url/path to background image (non required if Card type is a 'tile')
+  - "image" (associative array) (default: ''): Url/path and alternate text of the background image (non required if Card type is a 'tile')
   - "tags" (array) (default: []): List of tags compatible with EC Tag component structure
   - "infos" (array) (default: []): List of infos. The format of each element in the array:
     - "label" (string) (default: ''): Label of info
@@ -36,11 +36,14 @@ npm install --save @ecl-twig/ec-component-card
   card: { 
     type: 'default', 
     description: 'Transparently designing and evaluating evidence-based EU legislation, backed by citizens views.', 
-    image: 'https://v2--europa-component-library.netlify.com/example-image.jpg', 
+    image: { 
+      src: 'https://v2--europa-component-library.netlify.com/example-image.jpg', 
+      alt: 'Better regulation', 
+    }, 
     title: { 
       type: 'standalone', 
-      path:  '/example', 
-      label: Better regulation', 
+      path: '/example', 
+      label: 'Better regulation', 
     }, 
     meta: [ 'Meta 1', 'Meta 2', 'Meta 3' ], 
     infos: [ 

--- a/src/ec/packages/ec-component-card/docs/card.md
+++ b/src/ec/packages/ec-component-card/docs/card.md
@@ -15,7 +15,7 @@ npm install --save @ecl-twig/ec-component-card
   - "description" (string) (default: '') - Description of card
   - "meta" (array) (default: []) - Meta's for the Card
   - "title" (associative array) (default: {}) - Predefined structure compatible with Link component. If Card type is a 'tile', only label property is required.
-  - "image" (associative array) (default: ''): Url/path and alternate text of the background image (non required if Card type is a 'tile')
+  - "image" (associative array) (default: ''): - Url/path and alternate text of the background image (non required if Card type is a 'tile')
   - "tags" (array) (default: []): List of tags compatible with EC Tag component structure
   - "infos" (array) (default: []): List of infos. The format of each element in the array:
     - "label" (string) (default: ''): Label of info


### PR DESCRIPTION
# PR description

Adding image alternate text variable to ec-component-card.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
