### PR TITLE
fix(contextual-navigation): Put back contextual-navigation component in main package file - TWIG-68

### DIFF
--- a/src/ec/packages/ec-components/package.json
+++ b/src/ec/packages/ec-components/package.json
@@ -15,6 +15,7 @@
     "@ecl-twig/ec-component-button": "2.11.0",
     "@ecl-twig/ec-component-card": "2.11.0",
     "@ecl-twig/ec-component-checkbox": "2.11.0",
+    "@ecl-twig/ec-component-contextual-navigation": "2.11.0",
     "@ecl-twig/ec-component-date-block": "2.11.0",
     "@ecl-twig/ec-component-description-list": "2.11.0",
     "@ecl-twig/ec-component-dropdown-legacy": "2.11.0",


### PR DESCRIPTION


# PR description

Please drop a few lines about the PR: what it does, how to test it, etc.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
