### PR TITLE
feat(deprecated): old site header and footer are now deprecated

### DIFF
--- a/src/ec/packages/ec-component-accordion/accordion.story.js
+++ b/src/ec/packages/ec-component-accordion/accordion.story.js
@@ -11,12 +11,12 @@ import demoData from './demo/data';
 import accordion from './accordion.html.twig';
 import notes from './docs/accordion.md';
 
-storiesOf('Components/Accordion', module)
+storiesOf('Components/deprecated/Accordion', module)
   .addDecorator(withKnobs)
   .addDecorator(withCode)
   .addDecorator(withNotes)
   .add(
-    '[deprecated] ECL < 2.6.0',
+    'ECL < 2.6.0 - default',
     () => {
       // This needs to be in the scope of this function.
       // Called on knob's change of value.

--- a/src/ec/packages/ec-component-footer/footer.story.js
+++ b/src/ec/packages/ec-component-footer/footer.story.js
@@ -23,19 +23,19 @@ sections.forEach(s => {
   });
 });
 
-storiesOf('Components/Footer', module)
+storiesOf('Components/deprecated/Footer', module)
   .addDecorator(withKnobs)
   .addDecorator(withCode)
   .addDecorator(withNotes)
   .add(
-    'corporate',
+    'ECL < 2.12.0 - corporate',
     () => footer({ back_to_top: backToTop, sections, common }),
     {
       notes: { markdown: notes },
     }
   )
   .add(
-    'custom',
+    'ECL < 2.12.0 - custom',
     () => footer({ back_to_top: backToTop, identity, sections, common }),
     {
       notes: { markdown: notes },

--- a/src/ec/packages/ec-component-site-header/site-header.story.js
+++ b/src/ec/packages/ec-component-site-header/site-header.story.js
@@ -12,12 +12,12 @@ import { englishData, frenchData } from './demo/data';
 import siteHeaderDocs from './README.md';
 import siteHeader from './site-header.html.twig';
 
-storiesOf('Components/Site Header', module)
+storiesOf('Components/deprecated/Site Header', module)
   .addDecorator(withKnobs)
   .addDecorator(withNotes)
   .addDecorator(withCode)
   .add(
-    'default',
+    'ECL < 2.12 - default',
     () => {
       englishData.icon_file_path = defaultSprite;
       englishData.logo.src = englishBanner;
@@ -28,7 +28,7 @@ storiesOf('Components/Site Header', module)
     }
   )
   .add(
-    'translated',
+    'ECL < 2.12 - translated',
     () => {
       frenchData.icon_file_path = defaultSprite;
       frenchData.logo.src = frenchBanner;


### PR DESCRIPTION
# PR description

I opted for grouping the deprecated components all together, now that we have three, it would otherwise start to be terribly confusing.
So in storybook you will now find footer, accordion and site-header in a common "folder" named "deprecated". 

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
