### PR TITLE
fix(hide-not-ready-components): Hiding site headers containing a menu - TWIG-161

### DIFF
--- a/src/ec/packages/ec-component-menu-harmonised/menu-harmonised.story.js.bckp
+++ b/src/ec/packages/ec-component-menu-harmonised/menu-harmonised.story.js.bckp
@@ -1,0 +1,41 @@
+import merge from 'deepmerge';
+import { storiesOf } from '@storybook/html';
+import { withNotes } from '@ecl-twig/storybook-addon-notes';
+import withCode from '@ecl-twig/storybook-addon-code';
+import iconPath from '@ecl/ec-resources-icons/dist/sprites/icons.svg';
+
+import dataGroup1 from './demo/data--group1';
+import dataGroup2 from './demo/data--group2';
+
+import menuStandardised from './ecl-menu-harmonised.html.twig';
+import notes from './README.md';
+
+storiesOf('Components/Menus/Harmonised', module)
+  .addDecorator(withNotes)
+  .addDecorator(withCode)
+  .add(
+    'group 1',
+    () =>
+      menuStandardised(
+        merge(dataGroup1, {
+          group: 'group1',
+          icon_path: iconPath,
+        })
+      ),
+    {
+      notes: { markdown: notes, json: dataGroup1 },
+    }
+  )
+  .add(
+    'group 2',
+    () =>
+      menuStandardised(
+        merge(dataGroup2, {
+          group: 'group2',
+          icon_path: iconPath,
+        })
+      ),
+    {
+      notes: { markdown: notes, json: dataGroup2 },
+    }
+  );

--- a/src/ec/packages/ec-component-menu-standardised/menu-standardised.story.js.bckp
+++ b/src/ec/packages/ec-component-menu-standardised/menu-standardised.story.js.bckp
@@ -1,0 +1,36 @@
+import { storiesOf } from '@storybook/html';
+import { withNotes } from '@ecl-twig/storybook-addon-notes';
+import withCode from '@ecl-twig/storybook-addon-code';
+import iconPath from '@ecl/ec-resources-icons/dist/sprites/icons.svg';
+
+import enData from './demo/data--en';
+import frData from './demo/data--fr';
+
+import menuStandardised from './ecl-menu-standardised.html.twig';
+import notes from './README.md';
+
+storiesOf('Components/Menus/Standardised', module)
+  .addDecorator(withNotes)
+  .addDecorator(withCode)
+  .add(
+    'default',
+    () => {
+      const fullDemoData = { ...enData, icon_path: iconPath };
+
+      return menuStandardised(fullDemoData);
+    },
+    {
+      notes: { markdown: notes, json: enData },
+    }
+  )
+  .add(
+    'translated',
+    () => {
+      const fullDemoData = { ...frData, icon_path: iconPath };
+
+      return menuStandardised(fullDemoData);
+    },
+    {
+      notes: { markdown: notes, json: frData },
+    }
+  );

--- a/src/ec/packages/ec-component-site-header-harmonised/site-header-harmonised.story.js.bckp
+++ b/src/ec/packages/ec-component-site-header-harmonised/site-header-harmonised.story.js.bckp
@@ -1,0 +1,48 @@
+import merge from 'deepmerge';
+import { storiesOf } from '@storybook/html';
+import { withNotes } from '@ecl-twig/storybook-addon-notes';
+import withCode from '@ecl-twig/storybook-addon-code';
+
+import defaultSprite from '@ecl/ec-resources-icons/dist/sprites/icons.svg';
+import logo from '@ecl/ec-resources-logo/logo--en.svg';
+import siteHeaderHarmonised from './ecl-site-header-harmonised.html.twig';
+import dataGroup1 from './demo/data--group1';
+import dataGroup2 from './demo/data--group2';
+import notes from './README.md';
+
+storiesOf('Components/Site Headers/Harmonised', module)
+  .addDecorator(withNotes)
+  .addDecorator(withCode)
+  .add(
+    'group 1',
+    () =>
+      siteHeaderHarmonised(
+        merge(dataGroup1, {
+          logo: {
+            src: logo,
+          },
+          group: 'group1',
+          logged: true,
+          icon_file_path: defaultSprite,
+        })
+      ),
+    {
+      notes: { markdown: notes, json: dataGroup1 },
+    }
+  )
+  .add(
+    'group 2',
+    () =>
+      siteHeaderHarmonised(
+        merge(dataGroup2, {
+          logo: {
+            src: logo,
+          },
+          group: 'group2',
+          icon_file_path: defaultSprite,
+        })
+      ),
+    {
+      notes: { markdown: notes, json: dataGroup2 },
+    }
+  );

--- a/src/ec/packages/ec-component-site-header-standardised/site-header-standardised.story.js.bckp
+++ b/src/ec/packages/ec-component-site-header-standardised/site-header-standardised.story.js.bckp
@@ -1,0 +1,70 @@
+import merge from 'deepmerge';
+import { storiesOf } from '@storybook/html';
+import { withNotes } from '@ecl-twig/storybook-addon-notes';
+import withCode from '@ecl-twig/storybook-addon-code';
+
+import defaultSprite from '@ecl/ec-resources-icons/dist/sprites/icons.svg';
+import englishBanner from '@ecl/ec-resources-logo/logo--en.svg';
+import frenchBanner from '@ecl/ec-resources-logo/logo--fr.svg';
+
+import englishData from './demo/data--en';
+import frenchData from './demo/data--fr';
+
+import siteHeaderStandardised from './ecl-site-header-standardised.html.twig';
+import notes from './README.md';
+
+frenchData.icon_file_path = defaultSprite;
+frenchData.logo.src = frenchBanner;
+englishData.icon_file_path = defaultSprite;
+englishData.logo.src = englishBanner;
+
+storiesOf('Components/Site Headers/Standardised', module)
+  .addDecorator(withNotes)
+  .addDecorator(withCode)
+  .add(
+    'default',
+    () =>
+      siteHeaderStandardised(
+        merge(englishData, {
+          logo: {
+            src: frenchBanner,
+          },
+          icon_file_path: defaultSprite,
+          logged: false,
+        })
+      ),
+    {
+      notes: { markdown: notes, json: englishData },
+    }
+  )
+  .add(
+    'logged in',
+    () =>
+      siteHeaderStandardised(
+        merge(englishData, {
+          logo: {
+            src: englishBanner,
+          },
+          icon_file_path: defaultSprite,
+          logged: true,
+        })
+      ),
+    {
+      notes: { markdown: notes, json: englishData },
+    }
+  )
+  .add(
+    'translated',
+    () =>
+      siteHeaderStandardised(
+        merge(frenchData, {
+          logo: {
+            src: frenchBanner,
+          },
+          icon_file_path: defaultSprite,
+        })
+      ),
+    {
+      notes: { markdown: notes, json: frenchData },
+    }
+  );


### PR DESCRIPTION


# PR description

Please drop a few lines about the PR: what it does, how to test it, etc.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
