### PR TITLE
fix(menu): href attribute needs quotes - TWIG-187

### DIFF
--- a/src/ec/packages/ec-component-menu/ecl-menu.html.twig
+++ b/src/ec/packages/ec-component-menu/ecl-menu.html.twig
@@ -66,7 +66,7 @@
   <div class="ecl-container">
     <a
       class="ecl-link ecl-link--standalone ecl-menu__toggle"
-      href={{ toggle_path }}
+      href="{{ toggle_path }}"
       data-ecl-menu-toggle
     >
       <div class="ecl-menu__toggle-open">


### PR DESCRIPTION
# PR description

Please drop a few lines about the PR: what it does, how to test it, etc.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
