### PR TITLE
fix(ecl-diff): Browsing Ecl website with puppeteer - TWIG-235

### DIFF
--- a/php/php_storybook/scripts/ecl-diff.js
+++ b/php/php_storybook/scripts/ecl-diff.js
@@ -250,6 +250,8 @@ yargsInteractive()
             el = 'languagelist';
           } else if (el === 'ordered-list' || el === 'unordered-list') {
             el = 'list';
+          } else if (el === 'page-header') {
+            el = 'pageheader';
           }
 
           return el;

--- a/php/php_storybook/scripts/ecl-diff.js
+++ b/php/php_storybook/scripts/ecl-diff.js
@@ -9,7 +9,6 @@ const puppeteer = require('puppeteer');
 const decode = require('decode-html');
 const yargsInteractive = require('yargs-interactive');
 const { HtmlDiffer } = require('html-differ');
-
 const { execSync } = require('child_process');
 
 const eclVersions = execSync('npm view @ecl/ec-component-link versions')
@@ -137,7 +136,6 @@ yargsInteractive()
         }
 
         const version = `v${eclVersion}`;
-
         const twigFullPath =
           language === 'php'
             ? `${systemFolder}/${component}`
@@ -161,6 +159,7 @@ yargsInteractive()
           });
 
           files = files.map(getVariant);
+          // We might have empty items in the array now.
           files = files.filter(item => item);
 
           if (files.length > 0) {
@@ -177,6 +176,10 @@ yargsInteractive()
                 )}`
               );
             }
+          } else {
+            console.error(
+              `Most likely the "${component}" component doesn't have any variant on the twig side and you tried to pass one.`
+            );
           }
 
           process.exit(1);
@@ -245,6 +248,8 @@ yargsInteractive()
             el = 'in-page-navigation';
           } else if (el === 'language-list') {
             el = 'languagelist';
+          } else if (el === 'ordered-list' || el === 'unordered-list') {
+            el = 'list';
           }
 
           return el;
@@ -263,7 +268,7 @@ yargsInteractive()
         const page = await browser.newPage();
         await page.goto(eclFinalUrl, { waitUntil: 'domcontentloaded' });
         // We might be redirected if the url doesn't exist.
-        await page.waitFor(2000);
+        await page.waitFor(5000);
         // If we have been redirected we try to look for the available variants.
         if (page.url() !== eclFinalUrl) {
           // Grouping link.

--- a/php/php_storybook/scripts/ecl-diff.js
+++ b/php/php_storybook/scripts/ecl-diff.js
@@ -80,7 +80,15 @@ const options = {
     describe: 'Is the component nested into a sub-section?',
     default: 'none',
     prompt: 'always',
-    choices: ['none', 'forms', 'navigation', 'banners'],
+    choices: [
+      'none',
+      'forms',
+      'navigation',
+      'banners',
+      'page-headers',
+      'site-headers',
+      'footers',
+    ],
   },
   eclStory: {
     type: 'input',
@@ -225,23 +233,23 @@ yargsInteractive()
           } else if (el === 'social-media-share') {
             el = 'socialmediashare';
           } else if (el === 'footer-harmonised') {
-            el = 'footers-harmonised';
+            el = 'harmonised';
           } else if (el === 'footer-core') {
-            el = 'footers-core';
+            el = 'core';
           } else if (el === 'footer-standardised') {
-            el = 'footers-standardised';
+            el = 'standardised';
           } else if (el === 'site-header-standardised') {
-            el = 'site-headers-standardised';
+            el = 'standardised';
           } else if (el === 'site-header-harmonised') {
-            el = 'site-headers-harmonised';
+            el = 'harmonised';
           } else if (el === 'site-header-core') {
-            el = 'site-headers-core';
+            el = 'core';
           } else if (el === 'page-header-core') {
-            el = 'page-headers-core';
+            el = 'core';
           } else if (el === 'page-header-harmonised') {
-            el = 'page-headers-harmonised';
+            el = 'harmonised';
           } else if (el === 'page-header-standardised') {
-            el = 'page-headers-standardised';
+            el = 'standardised';
           } else if (el === 'expandable') {
             el = 'expandables';
           } else if (el === 'inpage-navigation') {


### PR DESCRIPTION
# PR description

This started as a specific fix on the issue mentioned in the issue's title but i took the chance to fix many other issues while doing this, i hope with this we are close to a "final" version of this script (we will have to maintain it everytim eECL changes something in the storybook organisation, unfotunately).

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
