### PR TITLE
refactor(knobs): table optional/mandatory knobs - FRONT-924

### DIFF
--- a/src/ec/packages/ec-component-table/README.md
+++ b/src/ec/packages/ec-component-table/README.md
@@ -13,12 +13,16 @@ npm install --save @ecl-twig/ec-component-table
   - "label" (string or array of string)
   - "colspan" (string) (default: ''),
 - **"rows"** (array) (default: [])
+  [
   - "extra_attributes": (string) (default: '') Extra attributes for the row (space separated)
   - "extra_classes": (string) (default: '') Extra classes for the table row (space separated)
-  - "label" (string or array of string)
-  - "data-ecl-table-header" (string) (default: ''),
-  - "data-ecl-table-header-group" (string) (default: '')
-  - "group" (bool) (default: false),
+    {
+      - "label" (string or array of string)
+      - "data-ecl-table-header" (string) (default: ''),
+      - "data-ecl-table-header-group" (string) (default: '')
+      - "group" (bool) (default: false),
+    }
+  ],
 - **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated)
 - **"extra_attributes"** (optional) (array) (default: []) Extra attributes
   - "name" (string) Attribute name, eg. 'data-test'
@@ -29,123 +33,123 @@ npm install --save @ecl-twig/ec-component-table
 <!-- prettier-ignore -->
 ```twig
 {% include '@ecl-twig/ec-component-table/ecl-table.html.twig' with { 
-  zebra: true/boolean, 
-  headers: [
-  [
-    { label: 'Name' },
-    { label: 'Registration date' },
-    { label: 'Languages', colspan: '3' },
-  ],
-  [
-    { label: '' },
-    { label: '' },
-    { label: 'English' },
-    { label: 'French' },
-    { label: 'German' },
-  ],
-  ],
-  rows: [
-  [
-    extra_classes: 'an-extra-class',
-    extra_attributes: 'an-extra-attribute="with_a_value", another-attribute',
-    { label: 'John', 'data-ecl-table-header': 'Name' },
+  zebra: true, 
+  headers: [ 
+  [ 
+    { label: 'Name' }, 
+    { label: 'Registration date' }, 
+    { label: 'Languages', colspan: '3' }, 
+  ], 
+  [ 
+    { label: '' }, 
+    { label: '' }, 
+    { label: 'English' }, 
+    { label: 'French' }, 
+    { label: 'German' }, 
+  ], 
+  ], 
+  rows: [ 
+  [ 
+    extra_classes: 'an-extra-class', 
+    extra_attributes: 'an-extra-attribute="with_a_value", another-attribute', 
+    { label: 'John', 'data-ecl-table-header': 'Name' }, 
+    { 
+      label: 'September 14, 2013', 
+      'data-ecl-table-header': 'Registration date', 
+    }, 
+    { 
+      label: 'Yes', 
+      'data-ecl-table-header': 'English', 
+      'data-ecl-table-header-group': 'Language', 
+      group: true, 
+    }, 
     {
-      label: 'September 14, 2013',
-      'data-ecl-table-header': 'Registration date',
+      label: 'No', 
+      'data-ecl-table-header': 'French', 
+      group: true, 
+    }, 
+    { 
+      label: 'Yes', 
+      'data-ecl-table-header': 'German', 
+      group: true, 
+    }, 
+  ], 
+  [ 
+    extra_classes: 'an-extra-class', 
+    extra_attributes: 'an-extra-attribute', 
+    { label: 'Ron', 'data-ecl-table-header': 'Name' }, 
+    { 
+      label: 'October 23, 2014', 
+      'data-ecl-table-header': 'Registration date', 
     },
     {
-      label: 'Yes',
+      label: 'Yes', 
       'data-ecl-table-header': 'English',
-      'data-ecl-table-header-group': 'Language',
-      group: true,
-    },
-    {
-      label: 'No',
-      'data-ecl-table-header': 'French',
-      group: true,
-    },
-    {
-      label: 'Yes',
-      'data-ecl-table-header': 'German',
-      group: true,
-    },
-  ],
-  [
-    extra_classes: 'an-extra-class',
-    extra_attributes: 'an-extra-attribute',
-    { label: 'Ron', 'data-ecl-table-header': 'Name' },
-    {
-      label: 'October 23, 2014',
-      'data-ecl-table-header': 'Registration date',
+      'data-ecl-table-header-group': 'Language', 
+      group: true, 
+    }, 
+    { 
+      label: 'Yes', 
+      'data-ecl-table-header': 'French', 
+      group: true, 
     },
     {
       label: 'Yes',
-      'data-ecl-table-header': 'English',
-      'data-ecl-table-header-group': 'Language',
-      group: true,
-    },
+      'data-ecl-table-header': 'German', 
+      group: true, 
+    }, 
+  ], 
+  [ 
+    { label: 'Albert', 'data-ecl-table-header': 'Name' }, 
     {
-      label: 'Yes',
-      'data-ecl-table-header': 'French',
-      group: true,
-    },
-    {
-      label: 'Yes',
-      'data-ecl-table-header': 'German',
-      group: true,
-    },
-  ],
-  [
-    { label: 'Albert', 'data-ecl-table-header': 'Name' },
-    {
-      label: 'December 13, 2014',
-      'data-ecl-table-header': 'Registration date',
-    },
-    {
-      label: 'No',
-      'data-ecl-table-header': 'English',
-      'data-ecl-table-header-group': 'Language',
-      group: true,
-    },
-    {
-      label: 'No',
-      'data-ecl-table-header': 'French',
-      group: true,
-    },
-    {
-      label: 'Yes',
-      'data-ecl-table-header': 'German',
-      group: true,
-    },
-  ],
-  [
-    { label: 'Marcel', 'data-ecl-table-header': 'Name' },
-    {
-      label: 'January 12, 1995',
-      'data-ecl-table-header': 'Registration date',
-    },
-    {
-      label: 'Yes',
-      'data-ecl-table-header': 'English',
-      'data-ecl-table-header-group': 'Language',
-      group: true,
-    },
-    {
-      label: 'Yes',
-      'data-ecl-table-header': 'French',
-      group: true,
-    },
-    {
-      label: 'Yes',
-      'data-ecl-table-header': 'German',
-      group: true,
-    },
-  ],
-  ],
+      label: 'December 13, 2014', 
+      'data-ecl-table-header': 'Registration date', 
+    }, 
+    { 
+      label: 'No', 
+      'data-ecl-table-header': 'English', 
+      'data-ecl-table-header-group': 'Language', 
+      group: true, 
+    }, 
+    { 
+      label: 'No', 
+      'data-ecl-table-header': 'French', 
+      group: true, 
+    }, 
+    { 
+      label: 'Yes', 
+      'data-ecl-table-header': 'German', 
+      group: true, 
+    }, 
+  ], 
+  [ 
+    { label: 'Marcel', 'data-ecl-table-header': 'Name' }, 
+    { 
+      label: 'January 12, 1995', 
+      'data-ecl-table-header': 'Registration date', 
+    }, 
+    { 
+      label: 'Yes', 
+      'data-ecl-table-header': 'English', 
+      'data-ecl-table-header-group': 'Language', 
+      group: true, 
+    }, 
+    { 
+      label: 'Yes', 
+      'data-ecl-table-header': 'French', 
+      group: true, 
+    }, 
+    { 
+      label: 'Yes', 
+      'data-ecl-table-header': 'German', 
+      group: true, 
+    }, 
+  ], 
+  ], 
   extra_classes: 'my-extra-class-1 my-extra-class-2', 
   extra_attributes: [ 
     { name: 'data-test-1', value: 'data-test-value-1' }, 
     { name: 'data-test-2', value: 'data-test-value-2' } 
   ] 
-} %}
+} %} 
 ```

--- a/src/ec/packages/ec-component-table/README.md
+++ b/src/ec/packages/ec-component-table/README.md
@@ -16,13 +16,9 @@ npm install --save @ecl-twig/ec-component-table
   [
   - "extra_attributes": (string) (default: '') Extra attributes for the row (space separated)
   - "extra_classes": (string) (default: '') Extra classes for the table row (space separated)
-    {
-      - "label" (string or array of string)
-      - "data-ecl-table-header" (string) (default: ''),
-      - "data-ecl-table-header-group" (string) (default: '')
-      - "group" (bool) (default: false),
+    { - "label" (string or array of string) - "data-ecl-table-header" (string) (default: ''), - "data-ecl-table-header-group" (string) (default: '') - "group" (bool) (default: false),
     }
-  ],
+    ],
 - **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated)
 - **"extra_attributes"** (optional) (array) (default: []) Extra attributes
   - "name" (string) Attribute name, eg. 'data-test'

--- a/src/ec/packages/ec-component-table/__snapshots__/table.test.js.snap
+++ b/src/ec/packages/ec-component-table/__snapshots__/table.test.js.snap
@@ -1174,13 +1174,13 @@ exports[`EC - Table Multi renders correctly 1`] = `
         European Commission
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Type of contract"
       >
         Permanent official
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Location"
       >
         Brussels (Belgium), Luxembourg (Luxembourg), Strasbourg (France)
@@ -1190,32 +1190,32 @@ exports[`EC - Table Multi renders correctly 1`] = `
       class="ecl-table__row"
     >
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Job title"
       >
         Administators in Economic and Monetary Union Law
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="EFSI finance approved by EIB"
       >
         AD7
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell ecl-table__cell--group"
         data-ecl-table-header="Organization"
         data-ecl-table-header-group="Extra information"
       >
         European Commission
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Type of contract"
       >
         Permanent official
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Location"
       >
         Brussels (Belgium), Luxembourg (Luxembourg), Strasbourg (France)
@@ -1225,32 +1225,32 @@ exports[`EC - Table Multi renders correctly 1`] = `
       class="ecl-table__row"
     >
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Job title"
       >
         Administators in Financial rules appliable to the EU budget
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="EFSI finance approved by EIB"
       >
         AD7
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell ecl-table__cell--group"
         data-ecl-table-header="Organization"
         data-ecl-table-header-group="Extra information"
       >
         European Commission
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Type of contract"
       >
         Permanent official
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Location"
       >
         Brussels (Belgium), Luxembourg (Luxembourg), Strasbourg (France)
@@ -1260,32 +1260,32 @@ exports[`EC - Table Multi renders correctly 1`] = `
       class="ecl-table__row"
     >
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Job title"
       >
         Corporate Support Officer
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="EFSI finance approved by EIB"
       >
         FG IV
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell ecl-table__cell--group"
         data-ecl-table-header="Organization"
         data-ecl-table-header-group="Extra information"
       >
         European Commission
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Type of contract"
       >
         Permanent official
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Location"
       >
         Prague (Czech Republic)
@@ -1295,32 +1295,32 @@ exports[`EC - Table Multi renders correctly 1`] = `
       class="ecl-table__row"
     >
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Job title"
       >
         Policy Officer - Clean Energy For All Europeans
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="EFSI finance approved by EIB"
       >
         FG II, FG III, FG IV
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell ecl-table__cell--group"
         data-ecl-table-header="Organization"
         data-ecl-table-header-group="Extra information"
       >
         EU-LISA
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Type of contract"
       >
         Seconded National Expert (SNE)
       </td>
       <td
-        class="ecl-table__cell ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group ecl-table__cell--group"
+        class="ecl-table__cell"
         data-ecl-table-header="Location"
       >
         Vigo (Spain)

--- a/src/ec/packages/ec-component-table/ecl-table.html.twig
+++ b/src/ec/packages/ec-component-table/ecl-table.html.twig
@@ -38,7 +38,6 @@
 {% set _head_css_class = 'ecl-table__head' %}
 {% set _header_css_class = 'ecl-table__header' %}
 {% set _body_css_class = 'ecl-table__body' %}
-{% set _cell_css_class = 'ecl-table__cell' %}
 {% set _cell_header_group_class = 'ecl-table__cell--group' %}
 {% set _row_css_class = 'ecl-table__row' %}
 {% set _row_extra_attributes = '' %}
@@ -89,6 +88,7 @@
       {% endif %}
       <tr class="{{ _row_css_class }}"{{ _row_extra_attributes }}>
         {% for cell in row %}
+          {% set _cell_css_class = 'ecl-table__cell' %}
           {% set _cell_attribute = cell['data-ecl-table-header'] is not empty ? 'data-ecl-table-header="' ~ cell['data-ecl-table-header'] ~ '"' : '' %}
           {% if cell.group and cell['data-ecl-table-header-group'] is defined and cell['data-ecl-table-header-group'] is not empty %}
             {% set _cell_attribute = _cell_attribute ~ ' data-ecl-table-header-group="' ~ cell['data-ecl-table-header-group'] ~ '"' %}

--- a/src/ec/packages/ec-component-table/ecl-table.html.twig
+++ b/src/ec/packages/ec-component-table/ecl-table.html.twig
@@ -11,14 +11,17 @@
       ...
     ]
   - "rows" (array) (default: {}): format: [
+    [
+      "extra_attributes": (string) (default: ''),
+      "extra_classes": (string) (default: ''),
       {
-        "extra_attributes": (string) (default: ''),
-        "extra_classes": (string) (default: ''),
         "label" (string or array of string)
         "data-ecl-table-header" (string) (default: ''),
         "group" (bool) (default: false),
       },
       ...
+    ],
+    ...
     ]
   - "extra_classes" (string) (default: '')
   - "extra_attributes" (array) (default: []): format: [

--- a/src/ec/packages/ec-component-table/ecl-table.html.twig
+++ b/src/ec/packages/ec-component-table/ecl-table.html.twig
@@ -90,8 +90,8 @@
       <tr class="{{ _row_css_class }}"{{ _row_extra_attributes }}>
         {% for cell in row %}
           {% set _cell_attribute = cell['data-ecl-table-header'] is not empty ? 'data-ecl-table-header="' ~ cell['data-ecl-table-header'] ~ '"' : '' %}
-          {% if cell.group %}
-            {% set _cell_attribute = _cell_attribute ~ (cell['data-ecl-table-header-group'] is not empty ? ' data-ecl-table-header-group="' ~ cell['data-ecl-table-header-group'] ~ '"' : '') %}
+          {% if cell.group and cell['data-ecl-table-header-group'] is defined and cell['data-ecl-table-header-group'] is not empty %}
+            {% set _cell_attribute = _cell_attribute ~ ' data-ecl-table-header-group="' ~ cell['data-ecl-table-header-group'] ~ '"' %}
             {% set _cell_css_class = _cell_css_class ~ ' ' ~ _cell_header_group_class %}
           {% endif %}
           <td {{ _cell_attribute|raw }} class="{{ _cell_css_class }}" >{{ cell.label|raw }}</td>

--- a/src/ec/packages/ec-component-table/table.story.js
+++ b/src/ec/packages/ec-component-table/table.story.js
@@ -1,37 +1,65 @@
+/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
+import { getExtraKnobs, buttonLabels } from '@ecl-twig/story-utils';
 import withCode from '@ecl-twig/storybook-addon-code';
+import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 
 import dataDefault from '@ecl/ec-specs-table/demo/data--default';
 import dataMulti from '@ecl/ec-specs-table/demo/data--multi';
 import table from './ecl-table.html.twig';
 import notes from './README.md';
 
-const dataWithRowExtraAttributes = dataDefault;
-dataWithRowExtraAttributes.rows.forEach(row => {
-  row.extra_attributes = 'data-test data-test-another'; // eslint-disable-line no-param-reassign
-});
+const prepareTable = data => {
+  data.zebra = boolean('zebra', false, buttonLabels.cases);
+  data.headers[0].forEach((header, index) => {
+    header.label = text(
+      `headers[0][${index}].label`,
+      header.label,
+      buttonLabels.required
+    );
+    header.colspan = text(
+      `headers[0][${index}].colspan`,
+      header.colspan,
+      buttonLabels.optional
+    );
+  });
+  data.rows[0].forEach((row, index) => {
+    row.label = text(
+      `rows[0][${index}].label`,
+      row.label,
+      buttonLabels.required
+    );
+    row.extra_classes = text(
+      `rows[0][${index}].extra_classes`,
+      row.extra_classes,
+      buttonLabels.optional
+    );
+    row.group = boolean(`rows[0][${index}].group`, false, buttonLabels.cases);
+  });
 
+  getExtraKnobs(data);
+
+  return data;
+};
+const dataRowExtraAttributes = dataDefault;
 storiesOf('Components/Table', module)
   .addDecorator(withNotes)
   .addDecorator(withCode)
-  .add(
-    'default',
-    () => {
-      dataDefault.zebra = false;
-      return table(dataDefault);
-    },
-    {
-      notes: { markdown: notes, json: dataDefault },
-    }
-  )
+  .addDecorator(withKnobs)
+  .add('default', () => table(prepareTable(dataDefault)), {
+    notes: { markdown: notes, json: dataDefault },
+  })
   .add(
     'default with row extra attributes',
     () => {
-      return table(dataWithRowExtraAttributes);
+      dataRowExtraAttributes.rows.forEach(row => {
+        row.extra_attributes = 'data-test data-test-another'; // eslint-disable-line no-param-reassign
+      });
+      return table(prepareTable(dataRowExtraAttributes));
     },
     {
-      notes: { markdown: notes, json: dataWithRowExtraAttributes },
+      notes: { markdown: notes, json: dataRowExtraAttributes },
     }
   )
   .add(

--- a/src/ec/packages/ec-component-table/table.story.js
+++ b/src/ec/packages/ec-component-table/table.story.js
@@ -10,32 +10,93 @@ import dataMulti from '@ecl/ec-specs-table/demo/data--multi';
 import table from './ecl-table.html.twig';
 import notes from './README.md';
 
-const prepareTable = data => {
-  data.zebra = boolean('zebra', false, buttonLabels.cases);
-  data.headers[0].forEach((header, index) => {
-    header.label = text(
-      `headers[0][${index}].label`,
-      header.label,
-      buttonLabels.required
-    );
-    header.colspan = text(
-      `headers[0][${index}].colspan`,
-      header.colspan,
-      buttonLabels.optional
-    );
+// Preserve original data
+const defaultData = { ...dataDefault };
+const dataZebra = { ...dataDefault, zebra: true };
+
+defaultData.rows.forEach(rows => {
+  rows.forEach(row => {
+    row.extra_attributes = [
+      { name: 'data-test' },
+      { name: 'data-test-another' },
+    ];
   });
-  data.rows[0].forEach((row, index) => {
-    row.label = text(
-      `rows[0][${index}].label`,
-      row.label,
-      buttonLabels.required
-    );
-    row.extra_classes = text(
-      `rows[0][${index}].extra_classes`,
-      row.extra_classes,
-      buttonLabels.optional
-    );
-    row.group = boolean(`rows[0][${index}].group`, false, buttonLabels.cases);
+});
+
+const prepareTable = data => {
+  data.zebra = boolean('zebra', data.zebra, buttonLabels.cases);
+  data.headers.forEach((headers, i) => {
+    headers.forEach((header, ind) => {
+      header.label = text(
+        `headers[${i}][${ind}].label`,
+        header.label,
+        buttonLabels.required
+      );
+      header.colspan = text(
+        `headers[${i}][${ind}].colspan`,
+        header.colspan,
+        buttonLabels.optional
+      );
+    });
+  });
+
+  data.rows.forEach((rows, i) => {
+    rows.forEach((row, ind) => {
+      row.label = text(
+        `rows[${i}][${ind}].label`,
+        row.label,
+        buttonLabels.required
+      );
+      row['data-ecl-table-header'] = text(
+        `rows[${i}][${ind}]['data-ecl-table-header']`,
+        row['data-ecl-table-header'],
+        buttonLabels.required
+      );
+      row.extra_classes = text(
+        `rows[${i}][${ind}].extra_classes`,
+        row.extra_classes,
+        buttonLabels.optional
+      );
+      if (!row.extra_attributes) {
+        row.extra_attributes = [];
+        row.extra_attributes[0] = {};
+        row.extra_attributes[1] = {};
+      }
+      row.extra_attributes[0].name = text(
+        `rows[${i}][${ind}].extra_attributes[0].name`,
+        row.extra_attributes[0].name,
+        buttonLabels.optional
+      );
+      row.extra_attributes[0].value = text(
+        `rows[${i}][${ind}].extra_attributes[0].value`,
+        row.extra_attributes[0].value,
+        buttonLabels.optional
+      );
+      if (row.extra_attributes[1].name) {
+        row.extra_attributes[1].name = text(
+          `rows[${i}][${ind}].extra_attributes[1].name`,
+          row.extra_attributes[1].name,
+          buttonLabels.optional
+        );
+        row.extra_attributes[1].value = text(
+          `rows[${i}][${ind}].extra_attributes[1].value`,
+          row.extra_attributes[1].value,
+          buttonLabels.optional
+        );
+      }
+      row.group = boolean(
+        `rows[${i}][${ind}].group`,
+        row.group,
+        buttonLabels.optional
+      );
+      if (data.rows[i][ind].group) {
+        row['data-ecl-table-header-group'] = text(
+          `rows[${i}][${ind}]['data-ecl-table-header-group']`,
+          row['data-ecl-table-header-group'],
+          buttonLabels.optional
+        );
+      }
+    });
   });
 
   getExtraKnobs(data);
@@ -47,58 +108,19 @@ storiesOf('Components/Table', module)
   .addDecorator(withNotes)
   .addDecorator(withCode)
   .addDecorator(withKnobs)
-  .add(
-    'default',
-    () => {
-      dataDefault.rows.forEach(row => {
-        delete row.extra_attributes;
-      });
-
-      return table(prepareTable(dataDefault));
-    },
-    {
-      notes: { markdown: notes, json: dataDefault },
-    }
-  )
+  .add('default', () => table(prepareTable(dataDefault)), {
+    notes: { markdown: notes, json: dataDefault },
+  })
   .add(
     'default with row extra attributes',
-    () => {
-      dataDefault.rows.forEach((row, index) => {
-        row.extra_attributes = text(
-          `rows[${index}].extra_attributes`,
-          'data-test data-test-another',
-          buttonLabels.optional
-        ); // eslint-disable-line no-param-reassign
-      });
-
-      return table(prepareTable(dataDefault));
-    },
+    () => table(prepareTable(defaultData)),
     {
-      notes: { markdown: notes, json: prepareTable(dataDefault) },
+      notes: { markdown: notes, json: defaultData },
     }
   )
-  .add(
-    'Zebra',
-    () => {
-      dataDefault.rows.forEach(row => {
-        delete row.extra_attributes;
-      });
-
-      return table(dataDefault);
-    },
-    {
-      notes: { markdown: notes, json: dataDefault },
-    }
-  )
-  .add(
-    'Multi',
-    () => {
-      dataMulti.rows.forEach(row => {
-        delete row.extra_attributes;
-      });
-      return table(dataMulti);
-    },
-    {
-      notes: { markdown: notes, json: dataMulti },
-    }
-  );
+  .add('Zebra', () => table(prepareTable(dataZebra)), {
+    notes: { markdown: notes, json: dataZebra },
+  })
+  .add('Multi', () => table(prepareTable(dataMulti)), {
+    notes: { markdown: notes, json: dataMulti },
+  });

--- a/src/ec/packages/ec-component-table/table.story.js
+++ b/src/ec/packages/ec-component-table/table.story.js
@@ -53,6 +53,7 @@ storiesOf('Components/Table', module)
       dataDefault.rows.forEach(row => {
         delete row.extra_attributes;
       });
+
       return table(prepareTable(dataDefault));
     },
     {
@@ -69,6 +70,7 @@ storiesOf('Components/Table', module)
           buttonLabels.optional
         ); // eslint-disable-line no-param-reassign
       });
+
       return table(prepareTable(dataDefault));
     },
     {
@@ -81,6 +83,7 @@ storiesOf('Components/Table', module)
       dataDefault.rows.forEach(row => {
         delete row.extra_attributes;
       });
+
       return table(dataDefault);
     },
     {
@@ -90,7 +93,7 @@ storiesOf('Components/Table', module)
   .add(
     'Multi',
     () => {
-      dataDefault.rows.forEach(row => {
+      dataMulti.rows.forEach(row => {
         delete row.extra_attributes;
       });
       return table(dataMulti);

--- a/src/ec/packages/ec-component-table/table.story.js
+++ b/src/ec/packages/ec-component-table/table.story.js
@@ -42,30 +42,45 @@ const prepareTable = data => {
 
   return data;
 };
-const dataRowExtraAttributes = dataDefault;
+
 storiesOf('Components/Table', module)
   .addDecorator(withNotes)
   .addDecorator(withCode)
   .addDecorator(withKnobs)
-  .add('default', () => table(prepareTable(dataDefault)), {
-    notes: { markdown: notes, json: dataDefault },
-  })
+  .add(
+    'default',
+    () => {
+      dataDefault.rows.forEach(row => {
+        delete row.extra_attributes;
+      });
+      return table(prepareTable(dataDefault));
+    },
+    {
+      notes: { markdown: notes, json: dataDefault },
+    }
+  )
   .add(
     'default with row extra attributes',
     () => {
-      dataRowExtraAttributes.rows.forEach(row => {
-        row.extra_attributes = 'data-test data-test-another'; // eslint-disable-line no-param-reassign
+      dataDefault.rows.forEach((row, index) => {
+        row.extra_attributes = text(
+          `rows[${index}].extra_attributes`,
+          'data-test data-test-another',
+          buttonLabels.optional
+        ); // eslint-disable-line no-param-reassign
       });
-      return table(prepareTable(dataRowExtraAttributes));
+      return table(prepareTable(dataDefault));
     },
     {
-      notes: { markdown: notes, json: dataRowExtraAttributes },
+      notes: { markdown: notes, json: prepareTable(dataDefault) },
     }
   )
   .add(
     'Zebra',
     () => {
-      dataDefault.zebra = true;
+      dataDefault.rows.forEach(row => {
+        delete row.extra_attributes;
+      });
       return table(dataDefault);
     },
     {
@@ -75,6 +90,9 @@ storiesOf('Components/Table', module)
   .add(
     'Multi',
     () => {
+      dataDefault.rows.forEach(row => {
+        delete row.extra_attributes;
+      });
       return table(dataMulti);
     },
     {


### PR DESCRIPTION
# PR description

There is a problem with the notes panel, basically for the way we set in the data the extra_attributes and extra-classes for the rows, when we go rendering that in the panel we lose these information.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
