### PR TITLE
feat(menuV2): Implementation, green diff with ECL - FRONT-991

### DIFF
--- a/src/ec/.storybook/preview-head.html
+++ b/src/ec/.storybook/preview-head.html
@@ -1,26 +1,26 @@
 <link
   rel="stylesheet"
-  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.25.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website.css"
-  integrity="sha256-jLoLiIK7yWFPpI/axzmIXWV6wfCFk+vWff1KHfG3wU4=
-  sha384-M9mVXi2EnOnGtZoqEh26Vp6610Eq0MgNFRur9p092rTX9iyZmLbBBP/UDG4YmJYu
-  sha512-rkho3ZV4eX5QI4WZxvIDBSleVFWEprTjG/aTexuBzm53cpXZ5D56WtlKBAh5IRulfKif5W75DuTbDIwYnc4Riw=="
+  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.26.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website.css"
+  integrity="sha256-kI8MyrCsKja5QwXuLUEOzTW9J962/YG47vjKtOLWKhQ=
+  sha384-qvYesWvUyahC12FW/FRYthpZxt1J+N7gkHjyH2ZieDYOQ0OaZ5xLNTkCS5P86A4Y
+  sha512-DIJvBuW1AZTQIYflUfHvFHapeDtKH1ie8KJ3l4wNbON3YnC+ZJV06J2pLuyPqAJNtof9jUs8JzIcYgNvPqH7OQ=="
   crossorigin="anonymous"
   media="screen"
 />
 <link
   rel="stylesheet"
-  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.25.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website-print.css"
-  integrity="sha256-FBPgWUNHS2UNloWd5kWNViSQcUj6C7sM0wqrtCiq1dw=
-  sha384-7DfgKATopHPKXqIrBwHbKmVJ39OWvQnJUg7weRgW4IUb9GgFdjixARPW9LAgGvoX
-  sha512-6gWgkvD6Nr530UaI8EOZeH0C8IA4Lyj05Q3TjKlFm+hsGimFG3GGqtLTmqzPlRHb5ldonVbZID4sMVw0EcWfqA=="
+  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.26.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website-print.css"
+  integrity="sha256-JdddxtVhWiExZxd1Q21OP2TzVAjqQecgF1YSftJXEag=
+  sha384-/yFYisyBbjd0cbtLpaiZTKIm/zbgK5PUodbpaNvecHnHH5xYhFnm8q+sfONiqzI2
+  sha512-+f/g0lvsVbNERooO5rYxGA67aLikYs+KaQiDyRay8FnZen6jh0wzq6pTb8oUJAXkYaJHDIpaXTGTUgS+Zw2Msg=="
   crossorigin="anonymous"
   media="print"
 />
 <script
-  src="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.25.0/ec-preset-legacy-website/scripts/ecl-ec-preset-legacy-website.js"
-  integrity="sha256-zPf7KEz1Ok4EXIS+4ye0SHgg+FmU5pvvo1nqmfVWI9U=
-  sha384-iitZ5AhKSLmseMELLcsULt2aGC32/4b4g18esn2sS7pwsuj4HGmt/jZQhXVqUb+9
-  sha512-Tc96AAYUQwqw5S+db8KIkucdNBuvB7VRUK8RedO2H6eUZ8Sf6w9CXfMGHnYlT2dQ0IWWWHVrW5rqJelwoilNig=="
+  src="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.26.0/ec-preset-legacy-website/scripts/ecl-ec-preset-legacy-website.js"
+  integrity="sha256-zfSH8h6BoNCNQsmhs30mR9yp8tw7Q/Ae8+r2yk630IY=
+  sha384-SijM6SXPm7PYZ6hVETRn0W7a4EuEZ0ZzS9KTU67YF9DcVCJJp9M+bP4AYhd5yfP+
+  sha512-NOpkyOZS0734W6QAD6vNSUCeoBRP8jUNWie+XbvUJqK1FqgsLK2F0CVg8+OqvklIwdMacnRDwyMX0DVVXF91TA=="
   crossorigin="anonymous"
 ></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.8.3/polyfill.min.js"></script>

--- a/src/ec/packages/ec-component-menu/README.md
+++ b/src/ec/packages/ec-component-menu/README.md
@@ -8,6 +8,9 @@ npm install --save @ecl-twig/ec-component-menu
 
 ### Parameters
 
+- **title:** (string) (default: ''): Title
+- **close:** (string) (default: ''): Close button label
+- **back:** (string): (default: ''): Back button label
 - **"group"** (string) (default: 'group1'): 'group1' or 'group2'
 - **"icon_path"** (string) (default: ''): Path to the icon sprite
 - **"items"** (associative array) (default: {}): The menu items - format:
@@ -19,8 +22,6 @@ npm install --save @ecl-twig/ec-component-menu
     "path": (string) (default: '')
     "is_current": (boolean) (optional),
 - **"site_name"** (string) (default: ''): Name of the website
-- **"toggle_label_close"** (string) (default: ''): Label of the toggler
-- **"toggle_label_open"** (string) (default: ''): Label of the toggler
 - **"toggle_path"** (string) (default: ''): Href attribute of the toggler
 - **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated) for the nav element
 - **"extra_attributes"** (optional) (array) (default: []) Extra attributes for the nav element
@@ -32,11 +33,11 @@ npm install --save @ecl-twig/ec-component-menu
 <!-- prettier-ignore -->
 ```twig
 {% include '@ecl-twig/ec-component-menu/ecl-menu.html.twig' with { 
-  label: "Menu", 
+  title: 'Menu', 
+  close: 'Close', 
+  back: 'Back', 
   icon_path: '/icons.svg', 
   site_name: 'Site name', 
-  toggle_label_close: 'Close', 
-  toggle_label_open: 'Open', 
   toggle_path: './example.com', 
   items: [ 
     { 

--- a/src/ec/packages/ec-component-menu/README.md
+++ b/src/ec/packages/ec-component-menu/README.md
@@ -11,7 +11,7 @@ npm install --save @ecl-twig/ec-component-menu
 - **title:** (string) (default: ''): Title
 - **close:** (string) (default: ''): Close button label
 - **back:** (string): (default: ''): Back button label
-- **"group"** (string) (default: 'group1'): 'group1' or 'group2'
+- **menu_link:** (string): (default: ''): Href attribute of the menu toggler
 - **"icon_path"** (string) (default: ''): Path to the icon sprite
 - **"items"** (associative array) (default: {}): The menu items - format:
   "label": (string) (default: '')
@@ -22,7 +22,6 @@ npm install --save @ecl-twig/ec-component-menu
     "path": (string) (default: '')
     "is_current": (boolean) (optional),
 - **"site_name"** (string) (default: ''): Name of the website
-- **"toggle_path"** (string) (default: ''): Href attribute of the toggler
 - **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated) for the nav element
 - **"extra_attributes"** (optional) (array) (default: []) Extra attributes for the nav element
   - "name" (string) Attribute name, eg. 'data-test'
@@ -38,7 +37,7 @@ npm install --save @ecl-twig/ec-component-menu
   back: 'Back', 
   icon_path: '/icons.svg', 
   site_name: 'Site name', 
-  toggle_path: './example.com', 
+  menu_link: './example.com', 
   items: [ 
     { 
       label: "Menu item", 

--- a/src/ec/packages/ec-component-menu/__snapshots__/menu.test.js.snap
+++ b/src/ec/packages/ec-component-menu/__snapshots__/menu.test.js.snap
@@ -8,1182 +8,1027 @@ exports[`EC - Menu Default renders correctly 1`] = `
   data-ecl-menu=""
 >
   <div
-    class="ecl-container"
+    class="ecl-menu__overlay"
+    data-ecl-menu-overlay=""
+  />
+  <div
+    class="ecl-container ecl-menu__container"
   >
     <a
-      class="ecl-link ecl-link--standalone ecl-menu__toggle"
-      data-ecl-menu-toggle=""
+      class="ecl-link ecl-link--standalone ecl-menu__open"
+      data-ecl-menu-open=""
       href="/example"
     >
-      <div
-        class="ecl-menu__toggle-open"
+      <svg
+        aria-hidden="true"
+        class="ecl-icon ecl-icon--s"
+        focusable="false"
       >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#general--hamburger"
-          />
-        </svg>
-        Menu
-      </div>
-      <div
-        class="ecl-menu__toggle-close"
-      >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#ui--close-filled"
-          />
-        </svg>
-        Close
-      </div>
+        <use
+          xlink:href="/icons.svg#general--hamburger"
+        />
+      </svg>
+      Menu
     </a>
     <div
       class="ecl-menu__site-name"
     >
       Site name
     </div>
-    <ul
-      class="ecl-menu__list"
-      data-ecl-menu-list=""
+    <section
+      class="ecl-menu__inner"
+      data-ecl-menu-inner=""
     >
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="false"
-        data-ecl-menu-item=""
+      <header
+        class="ecl-menu__inner-header"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <button
+          class="ecl-menu__close ecl-button ecl-button--text"
+          data-ecl-menu-close=""
+          type="submit"
         >
-          Home  
-        </a>
-      </li>
-      <li
-        class="ecl-menu__item ecl-menu__item--current"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link ecl-menu__link--current"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 1
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <span
+            class="ecl-menu__close-container ecl-button__container"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--close-filled"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label="true"
+            >
+              Close
+            </span>
+          </span>
+        </button>
         <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+          class="ecl-menu__title"
         >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem ecl-menu__subitem--current"
-            >
-              <a
-                class="ecl-menu__sublink ecl-menu__sublink--current"
-                href="/example"
-              >
-                Item 1.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.16
-              </a>
-            </li>
-          </ul>
+          Menu
         </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
+        <button
+          class="ecl-menu__back ecl-button ecl-button--text"
+          data-ecl-menu-back=""
+          type="submit"
+        >
+          <span
+            class="ecl-button__container"
+          >
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label=""
+            >
+              Back
+            </span>
+          </span>
+        </button>
+      </header>
+      <ul
+        class="ecl-menu__list"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <li
+          class="ecl-menu__item"
+          data-ecl-menu-item=""
         >
-          Item 2
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Home  
+          </a>
+        </li>
+        <li
+          class="ecl-menu__item ecl-menu__item--current"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link ecl-menu__link--current"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 2
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 2.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem ecl-menu__subitem--current"
+                data-ecl-menu-subitem=""
               >
-                Item 2.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink ecl-menu__sublink--current"
+                  href="/example"
+                >
+                  Item 2.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.9
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 3
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 3
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.3
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 4
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 3.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.3
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.3 with a very long label going on 2 lines
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.14
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 4
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 5
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.7
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 6
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 4.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.3 with a very long label
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.9 with a very long label
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.14
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 5
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
+            Item 7 with a long label
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
           >
-            <li
-              class="ecl-menu__subitem"
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 6
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 7 with a long label
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.4 with a very long label
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-    </ul>
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.10
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </section>
   </div>
 </nav>
 `;
@@ -1199,1182 +1044,1027 @@ exports[`EC - Menu Default renders correctly with extra attributes 1`] = `
   null=""
 >
   <div
-    class="ecl-container"
+    class="ecl-menu__overlay"
+    data-ecl-menu-overlay=""
+  />
+  <div
+    class="ecl-container ecl-menu__container"
   >
     <a
-      class="ecl-link ecl-link--standalone ecl-menu__toggle"
-      data-ecl-menu-toggle=""
+      class="ecl-link ecl-link--standalone ecl-menu__open"
+      data-ecl-menu-open=""
       href="/example"
     >
-      <div
-        class="ecl-menu__toggle-open"
+      <svg
+        aria-hidden="true"
+        class="ecl-icon ecl-icon--s"
+        focusable="false"
       >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#general--hamburger"
-          />
-        </svg>
-        Menu
-      </div>
-      <div
-        class="ecl-menu__toggle-close"
-      >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#ui--close-filled"
-          />
-        </svg>
-        Close
-      </div>
+        <use
+          xlink:href="/icons.svg#general--hamburger"
+        />
+      </svg>
+      Menu
     </a>
     <div
       class="ecl-menu__site-name"
     >
       Site name
     </div>
-    <ul
-      class="ecl-menu__list"
-      data-ecl-menu-list=""
+    <section
+      class="ecl-menu__inner"
+      data-ecl-menu-inner=""
     >
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="false"
-        data-ecl-menu-item=""
+      <header
+        class="ecl-menu__inner-header"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <button
+          class="ecl-menu__close ecl-button ecl-button--text"
+          data-ecl-menu-close=""
+          type="submit"
         >
-          Home  
-        </a>
-      </li>
-      <li
-        class="ecl-menu__item ecl-menu__item--current"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link ecl-menu__link--current"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 1
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <span
+            class="ecl-menu__close-container ecl-button__container"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--close-filled"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label="true"
+            >
+              Close
+            </span>
+          </span>
+        </button>
         <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+          class="ecl-menu__title"
         >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem ecl-menu__subitem--current"
-            >
-              <a
-                class="ecl-menu__sublink ecl-menu__sublink--current"
-                href="/example"
-              >
-                Item 1.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.16
-              </a>
-            </li>
-          </ul>
+          Menu
         </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
+        <button
+          class="ecl-menu__back ecl-button ecl-button--text"
+          data-ecl-menu-back=""
+          type="submit"
+        >
+          <span
+            class="ecl-button__container"
+          >
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label=""
+            >
+              Back
+            </span>
+          </span>
+        </button>
+      </header>
+      <ul
+        class="ecl-menu__list"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <li
+          class="ecl-menu__item"
+          data-ecl-menu-item=""
         >
-          Item 2
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Home  
+          </a>
+        </li>
+        <li
+          class="ecl-menu__item ecl-menu__item--current"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link ecl-menu__link--current"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 2
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 2.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem ecl-menu__subitem--current"
+                data-ecl-menu-subitem=""
               >
-                Item 2.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink ecl-menu__sublink--current"
+                  href="/example"
+                >
+                  Item 2.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.9
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 3
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 3
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.3
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 4
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 3.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.3
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.3 with a very long label going on 2 lines
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.14
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 4
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 5
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.7
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 6
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 4.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.3 with a very long label
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.9 with a very long label
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.14
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 5
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
+            Item 7 with a long label
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
           >
-            <li
-              class="ecl-menu__subitem"
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 6
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 7 with a long label
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.4 with a very long label
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-    </ul>
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.10
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </section>
   </div>
 </nav>
 `;
@@ -2387,1182 +2077,1027 @@ exports[`EC - Menu Default renders correctly with extra class names 1`] = `
   data-ecl-menu=""
 >
   <div
-    class="ecl-container"
+    class="ecl-menu__overlay"
+    data-ecl-menu-overlay=""
+  />
+  <div
+    class="ecl-container ecl-menu__container"
   >
     <a
-      class="ecl-link ecl-link--standalone ecl-menu__toggle"
-      data-ecl-menu-toggle=""
+      class="ecl-link ecl-link--standalone ecl-menu__open"
+      data-ecl-menu-open=""
       href="/example"
     >
-      <div
-        class="ecl-menu__toggle-open"
+      <svg
+        aria-hidden="true"
+        class="ecl-icon ecl-icon--s"
+        focusable="false"
       >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#general--hamburger"
-          />
-        </svg>
-        Menu
-      </div>
-      <div
-        class="ecl-menu__toggle-close"
-      >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#ui--close-filled"
-          />
-        </svg>
-        Close
-      </div>
+        <use
+          xlink:href="/icons.svg#general--hamburger"
+        />
+      </svg>
+      Menu
     </a>
     <div
       class="ecl-menu__site-name"
     >
       Site name
     </div>
-    <ul
-      class="ecl-menu__list"
-      data-ecl-menu-list=""
+    <section
+      class="ecl-menu__inner"
+      data-ecl-menu-inner=""
     >
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="false"
-        data-ecl-menu-item=""
+      <header
+        class="ecl-menu__inner-header"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <button
+          class="ecl-menu__close ecl-button ecl-button--text"
+          data-ecl-menu-close=""
+          type="submit"
         >
-          Home  
-        </a>
-      </li>
-      <li
-        class="ecl-menu__item ecl-menu__item--current"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link ecl-menu__link--current"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 1
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <span
+            class="ecl-menu__close-container ecl-button__container"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--close-filled"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label="true"
+            >
+              Close
+            </span>
+          </span>
+        </button>
         <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+          class="ecl-menu__title"
         >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem ecl-menu__subitem--current"
-            >
-              <a
-                class="ecl-menu__sublink ecl-menu__sublink--current"
-                href="/example"
-              >
-                Item 1.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.16
-              </a>
-            </li>
-          </ul>
+          Menu
         </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
+        <button
+          class="ecl-menu__back ecl-button ecl-button--text"
+          data-ecl-menu-back=""
+          type="submit"
+        >
+          <span
+            class="ecl-button__container"
+          >
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label=""
+            >
+              Back
+            </span>
+          </span>
+        </button>
+      </header>
+      <ul
+        class="ecl-menu__list"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <li
+          class="ecl-menu__item"
+          data-ecl-menu-item=""
         >
-          Item 2
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Home  
+          </a>
+        </li>
+        <li
+          class="ecl-menu__item ecl-menu__item--current"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link ecl-menu__link--current"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 2
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 2.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem ecl-menu__subitem--current"
+                data-ecl-menu-subitem=""
               >
-                Item 2.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink ecl-menu__sublink--current"
+                  href="/example"
+                >
+                  Item 2.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.9
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 3
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 3
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.3
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 4
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 3.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.3
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.3 with a very long label going on 2 lines
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.14
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 4
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 5
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.7
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 6
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 4.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.3 with a very long label
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.9 with a very long label
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.14
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 5
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
+            Item 7 with a long label
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
           >
-            <li
-              class="ecl-menu__subitem"
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 6
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 7 with a long label
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.4 with a very long label
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-    </ul>
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.10
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </section>
   </div>
 </nav>
 `;
@@ -3575,1402 +3110,1027 @@ exports[`EC - Menu Translated renders correctly 1`] = `
   data-ecl-menu=""
 >
   <div
-    class="ecl-container"
+    class="ecl-menu__overlay"
+    data-ecl-menu-overlay=""
+  />
+  <div
+    class="ecl-container ecl-menu__container"
   >
     <a
-      class="ecl-link ecl-link--standalone ecl-menu__toggle"
-      data-ecl-menu-toggle=""
+      class="ecl-link ecl-link--standalone ecl-menu__open"
+      data-ecl-menu-open=""
       href="/example"
     >
-      <div
-        class="ecl-menu__toggle-open"
+      <svg
+        aria-hidden="true"
+        class="ecl-icon ecl-icon--s"
+        focusable="false"
       >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#general--hamburger"
-          />
-        </svg>
-        Menu
-      </div>
-      <div
-        class="ecl-menu__toggle-close"
-      >
-        <svg
-          aria-hidden="true"
-          class="ecl-icon ecl-icon--s"
-          focusable="false"
-        >
-          <use
-            xlink:href="/icons.svg#ui--close-filled"
-          />
-        </svg>
-        Fermer
-      </div>
+        <use
+          xlink:href="/icons.svg#general--hamburger"
+        />
+      </svg>
+      Menu
     </a>
     <div
       class="ecl-menu__site-name"
     >
       Nom du site
     </div>
-    <ul
-      class="ecl-menu__list"
-      data-ecl-menu-list=""
+    <section
+      class="ecl-menu__inner"
+      data-ecl-menu-inner=""
     >
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="false"
-        data-ecl-menu-item=""
+      <header
+        class="ecl-menu__inner-header"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <button
+          class="ecl-menu__close ecl-button ecl-button--text"
+          data-ecl-menu-close=""
+          type="submit"
         >
-          Accueil  
-        </a>
-      </li>
-      <li
-        class="ecl-menu__item ecl-menu__item--current"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link ecl-menu__link--current"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 1
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <span
+            class="ecl-menu__close-container ecl-button__container"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--close-filled"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label="true"
+            >
+              Fermer
+            </span>
+          </span>
+        </button>
         <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+          class="ecl-menu__title"
         >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem ecl-menu__subitem--current"
-            >
-              <a
-                class="ecl-menu__sublink ecl-menu__sublink--current"
-                href="/example"
-              >
-                Item 1.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 1.16
-              </a>
-            </li>
-          </ul>
+          Menu
         </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
+        <button
+          class="ecl-menu__back ecl-button ecl-button--text"
+          data-ecl-menu-back=""
+          type="submit"
+        >
+          <span
+            class="ecl-button__container"
+          >
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+              data-ecl-icon=""
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+            <span
+              class="ecl-button__label"
+              data-ecl-label=""
+            >
+              Retour
+            </span>
+          </span>
+        </button>
+      </header>
+      <ul
+        class="ecl-menu__list"
       >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+        <li
+          class="ecl-menu__item"
+          data-ecl-menu-item=""
         >
-          Item 2
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Accueil  
+          </a>
+        </li>
+        <li
+          class="ecl-menu__item ecl-menu__item--current"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link ecl-menu__link--current"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 2
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 2.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem ecl-menu__subitem--current"
+                data-ecl-menu-subitem=""
               >
-                Item 2.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink ecl-menu__sublink--current"
+                  href="/example"
+                >
+                  Item 2.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 2.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 2.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 3
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 3
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 3.3
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 4
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 3.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.3 avec un long titre sur plusieurs lignes
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 3.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 3.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 4.14
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 4
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
+            Item 5
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
+            >
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 5.7
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          <ul
-            class="ecl-menu__sublist"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <li
-              class="ecl-menu__subitem"
+            Item 6
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 4.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
+          >
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.9 avec un long titre
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.10
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.11
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.12
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.13
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.14
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 4.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.15
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
+              >
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 6.16
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+        <li
+          class="ecl-menu__item"
+          data-ecl-has-children=""
+          data-ecl-menu-item=""
         >
-          Item 5
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
+          <a
+            class="ecl-menu__link"
+            data-ecl-menu-link=""
+            href="/example"
           >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
+            Item 7 avec un long titre
+            <svg
+              aria-hidden="true"
+              class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+              focusable="false"
+            >
+              <use
+                xlink:href="/icons.svg#ui--corner-arrow"
+              />
+            </svg>
+          </a>
+          <div
+            class="ecl-menu__mega"
+            data-ecl-menu-mega=""
           >
-            <li
-              class="ecl-menu__subitem"
+            <ul
+              class="ecl-menu__sublist"
             >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.1
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.2
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.3
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.4
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.5
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.6
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.7
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.8
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.9
+                </a>
+              </li>
+              <li
+                class="ecl-menu__subitem"
+                data-ecl-menu-subitem=""
               >
-                Item 5.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 5.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 6
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 6.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-      <li
-        class="ecl-menu__item"
-        data-ecl-has-children="true"
-        data-ecl-menu-item=""
-      >
-        <a
-          class="ecl-menu__link"
-          data-ecl-menu-link=""
-          href="/example"
-        >
-          Item 7 avec un long titre
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--corner-arrow"
-            />
-          </svg>
-        </a>
-        <div
-          class="ecl-menu__mega"
-          data-ecl-menu-mega=""
-        >
-          <ul
-            class="ecl-menu__sublist"
-          >
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.1
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.2
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.3
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.4
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.5
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.6
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.7
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.8
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.9
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.10
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.11
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.12
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.13
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.14
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.15
-              </a>
-            </li>
-            <li
-              class="ecl-menu__subitem"
-            >
-              <a
-                class="ecl-menu__sublink"
-                href="/example"
-              >
-                Item 7.16
-              </a>
-            </li>
-          </ul>
-        </div>
-      </li>
-    </ul>
+                <a
+                  class="ecl-menu__sublink"
+                  href="/example"
+                >
+                  Item 7.10
+                </a>
+              </li>
+            </ul>
+          </div>
+        </li>
+      </ul>
+    </section>
   </div>
 </nav>
 `;

--- a/src/ec/packages/ec-component-menu/adapter.js
+++ b/src/ec/packages/ec-component-menu/adapter.js
@@ -4,14 +4,10 @@ const adapter = initialData => {
   // Copy reference specification demo adaptedData.
   const adaptedData = JSON.parse(JSON.stringify(initialData));
   adaptedData.icon_path = '/icons.svg';
-  adaptedData.toggle_label_open = adaptedData.toggleLabelOpen;
-  delete adaptedData.toggleLabelOpen;
-  adaptedData.toggle_label_close = adaptedData.toggleLabelClose;
-  adaptedData.toggle_path = '/example';
-  delete adaptedData.toggleLabelClose;
   adaptedData.site_name = adaptedData.siteName;
   delete adaptedData.siteName;
-
+  adaptedData.menu_link = adaptedData.menuLink;
+  delete adaptedData.menuLink;
   if (adaptedData.items && Array.isArray(adaptedData.items)) {
     adaptedData.items.forEach(mainItem => {
       mainItem.path = mainItem.href;

--- a/src/ec/packages/ec-component-menu/ecl-menu-item.html.twig
+++ b/src/ec/packages/ec-component-menu/ecl-menu-item.html.twig
@@ -11,9 +11,7 @@
 {% endif %}
 
 {% if item.children is defined and item.children is not empty %}
-  {% set _menu_list_item_attributes = _menu_list_item_attributes ~ ' data-ecl-has-children=true' %}
-{% else %}
-  {% set _menu_list_item_attributes = _menu_list_item_attributes ~ ' data-ecl-has-children=false' %}
+  {% set _menu_list_item_attributes = _menu_list_item_attributes ~ ' data-ecl-has-children' %}
 {% endif %}
 
 <li class="{{ _menu_list_item_class }}" {{ _menu_list_item_attributes }}>
@@ -26,7 +24,7 @@
           type: 'ui',
           name: 'corner-arrow',
           size: 'xs',
-          transform: 'rotate-180'
+          transform: 'rotate-90'
         },
         extra_classes: 'ecl-menu__link-icon',
       } %}
@@ -39,10 +37,19 @@
   >
     <ul class="ecl-menu__sublist">
     {% for child in item.children %}
-      {% set _subitem_class = 'ecl-menu__subitem' ~ (child.is_current is defined ? ' ecl-menu__subitem--current' : '') %}
-      <li class="{{ _subitem_class }}">
+      {% set _subitem_class = 'ecl-menu__subitem' %}
+      {% if child.is_current is defined %}
+        {% set _subitem_class = _subitem_class ~ ' ecl-menu__subitem--current' %}
+      {% endif %}
+      <li
+        class="{{ _subitem_class }}"
+        data-ecl-menu-subitem
+      >
         {% set _sublink_class = 'ecl-menu__sublink' ~ (child.is_current is defined ? ' ecl-menu__sublink--current' : '') %}
-        <a href="{{ child.path }}" class="{{ _sublink_class }}">
+        <a
+          href="{{ child.path }}"
+          class="{{ _sublink_class }}"
+        >
           {{- child.label -}}
         </a>
       </li>

--- a/src/ec/packages/ec-component-menu/ecl-menu.html.twig
+++ b/src/ec/packages/ec-component-menu/ecl-menu.html.twig
@@ -2,6 +2,9 @@
 
 {#
   Parameters:
+  - title: (string) (default: ''): Title
+  - close: (string) (default: ''): Close button label
+  - back: (string): (default: ''): Back button label
   - "group": (string) (default: 'group1'): 'group1' or 'group2'
   - "icon_path": (string) (default: ''): Path to the icon sprite
   - "items": (associative array) (default: {}): The menu items - format: [
@@ -27,9 +30,7 @@
     },
   }],
   - "site_name": (string) (default: ''): Name of the website
-  - "toggle_label_close": (string) (default: ''): Label of the toggler
-  - "toggle_label_open": (string) (default: ''): Label of the toggler
-  - "toggle_path": (string) (default: ''): Href attribute of the toggler
+  - "menu_link": (string) (default: ''): Href attribute of the menu toggler
   - "extra_classes" (optional) (string) (default: '') Extra classes (space separated) for the nav element
   - "extra_attributes" (optional) (array) (default: []) Extra attributes for the nav element
     - "name" (string) Attribute name, eg. 'data-test'
@@ -38,6 +39,10 @@
 
 {# Internal properties #}
 
+{% set _title = title|default('') %}
+{% set _back = back|default('') %}
+{% set _close = close|default('') %}
+{% set _menu_link = menu_link|default('') %}
 {% set _group = group|default('group1') %}
 {% set _css_class = 'ecl-menu' %}
 {% set _css_class = _css_class ~ ' ' ~ _css_class ~ '--' ~ _group %}
@@ -63,53 +68,88 @@
   aria-expanded="false"
   {{ _extra_attributes|raw }}
 >
-  <div class="ecl-container">
+  <div class="ecl-menu__overlay" data-ecl-menu-overlay></div>
+  <div class="ecl-container ecl-menu__container">
     <a
-      class="ecl-link ecl-link--standalone ecl-menu__toggle"
-      href="{{ toggle_path }}"
-      data-ecl-menu-toggle
+      class="ecl-link ecl-link--standalone ecl-menu__open"
+      href="{{ _menu_link }}"
+      data-ecl-menu-open
     >
-      <div class="ecl-menu__toggle-open">
-        {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
-          icon: {
-            size: 's',
-            type: 'general',
-            name: 'hamburger',
-            path: icon_path
-          }
-        } only %}
-        {{- toggle_label_open -}}
-      </div>
-      <div class="ecl-menu__toggle-close">
-        {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
-          icon: {
-            size: 's',
-            type: 'ui',
-            name: 'close-filled',
-            path: icon_path
-          }
-        } only %}
-        {{- toggle_label_close -}}
-      </div>
+      {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+        icon: {
+          size: 's',
+          type: 'general',
+          name: 'hamburger',
+          path: icon_path
+        }
+      } only %}
+      {{- title -}}
     </a>
-  {% if _group == 'group1' %}
     <div class="ecl-menu__site-name">{{ site_name }}</div>
-  {% endif %}
-    <ul
-      class="ecl-menu__list"
-      data-ecl-menu-list
-    >
-  {% if items is defined and items is not empty and items is iterable %}
-    {% for item in items %}
-      {% if item is defined and item is not empty %}
-        {% include '@ecl-twig/ec-component-menu/ecl-menu-item.html.twig' with {
-          item: item,
-          icon_path: icon_path,
-        } only %}
+    <section class="ecl-menu__inner" data-ecl-menu-inner>
+      <header class="ecl-menu__inner-header">
+        <button
+          class="ecl-menu__close ecl-button ecl-button--text"
+          type="submit"
+          data-ecl-menu-close
+        ><span class="ecl-menu__close-container ecl-button__container">
+            {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+              icon: {
+                path: icon_path,
+                name: 'close-filled',
+                type: 'ui',
+                size: 's',
+              },
+              extra_classes: 'ecl-button__icon ecl-button__icon--before',
+              extra_attributes: [{ name: 'data-ecl-icon' }]
+            } only %}
+            <span
+              class="ecl-button__label"
+              data-ecl-label="true">
+                {{- _close -}}
+            </span>
+          </span>
+        </button>
+        <div class="ecl-menu__title">{{- _title -}}</div>
+        <button
+          data-ecl-menu-back
+          type="submit"
+          class="ecl-menu__back ecl-button ecl-button--text"
+        >
+          <span class="ecl-button__container">
+            {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
+              icon: {
+                path: icon_path,
+                name: 'corner-arrow',
+                type: 'ui',
+                size: 's',
+                transform: 'rotate-270',
+              },
+              extra_classes: 'ecl-button__icon ecl-button__icon--before',
+              extra_attributes: [{ name: 'data-ecl-icon' }]
+            } only %}
+            <span
+              class="ecl-button__label"
+              data-ecl-label
+            >
+              {{- _back -}}
+            </span>
+          </span>
+        </button>
+      </header>
+      <ul class="ecl-menu__list">
+      {% if items is defined and items is not empty and items is iterable %}
+        {% for item in items %}
+        {% if item is defined and item is not empty %}
+          {% include '@ecl-twig/ec-component-menu/ecl-menu-item.html.twig' with {
+            item: item,
+            icon_path: icon_path,
+          } only %}
+        {% endif %}
+        {% endfor %}
       {% endif %}
-    {% endfor %}
-  {% endif %}
-    </ul>
+      </ul>
+    </section>
   </div>
 </nav>
 

--- a/src/ec/packages/ec-component-menu/menu.story.js
+++ b/src/ec/packages/ec-component-menu/menu.story.js
@@ -1,26 +1,41 @@
-import merge from 'deepmerge';
+/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
+import { withKnobs, select, text, object } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import withCode from '@ecl-twig/storybook-addon-code';
+import { getExtraKnobs, buttonLabels } from '@ecl-twig/story-utils';
+
 import iconPath from '@ecl/ec-resources-icons/dist/sprites/icons.svg';
-
 import enData from './demo/data--en';
-
+import frData from './demo/data--fr';
 import menu from './ecl-menu.html.twig';
 import notes from './README.md';
 
+const prepareMenu = data => {
+  data.title = text('title', data.title, buttonLabels.required);
+  data.close = text('close', data.close, buttonLabels.required);
+  data.back = text('back', data.back, buttonLabels.required);
+  data.icon_path = select(
+    'icon_path',
+    [iconPath],
+    iconPath,
+    buttonLabels.required
+  );
+
+  getExtraKnobs(data);
+
+  data.items = object('items', data.items, buttonLabels.optional);
+
+  return data;
+};
+
 storiesOf('Components/Navigation/Menu', module)
+  .addDecorator(withKnobs)
   .addDecorator(withNotes)
   .addDecorator(withCode)
-  .add(
-    'default',
-    () =>
-      menu(
-        merge(enData, {
-          icon_path: iconPath,
-        })
-      ),
-    {
-      notes: { markdown: notes, json: enData },
-    }
-  );
+  .add('default', () => menu(prepareMenu(enData)), {
+    notes: { markdown: notes, json: enData },
+  })
+  .add('translated', () => menu(prepareMenu(frData)), {
+    notes: { markdown: notes, json: frData },
+  });

--- a/src/ec/packages/ec-component-menu/package.json
+++ b/src/ec/packages/ec-component-menu/package.json
@@ -2,15 +2,15 @@
   "name": "@ecl-twig/ec-component-menu",
   "author": "European Commission",
   "license": "EUPL-1.1",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "description": "ECL Twig - EC Menu",
   "dependencies": {
     "@ecl-twig/ec-component-icon": "2.25.1"
   },
   "devDependencies": {
-    "@ecl/ec-component-menu": "2.25.0",
-    "@ecl/ec-resources-icons": "2.25.0",
-    "@ecl/ec-specs-menu": "2.25.0"
+    "@ecl/ec-component-menu": "2.26.0",
+    "@ecl/ec-resources-icons": "2.26.0",
+    "@ecl/ec-specs-menu": "2.26.0"
   },
   "publishConfig": {
     "access": "public"

--- a/src/ec/packages/ec-component-site-header-harmonised/__snapshots__/site-header-harmonised.test.js.snap
+++ b/src/ec/packages/ec-component-site-header-harmonised/__snapshots__/site-header-harmonised.test.js.snap
@@ -167,1402 +167,1027 @@ exports[`EC - Site Header Harmonised Group 1 renders correctly 1`] = `
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Site name
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -2136,1402 +1761,1027 @@ exports[`EC - Site Header Harmonised Group 1 renders correctly with extra attrib
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Site name
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -4103,1402 +3353,1027 @@ exports[`EC - Site Header Harmonised Group 1 renders correctly with extra class 
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Site name
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -6037,1397 +4912,1025 @@ exports[`EC - Site Header Harmonised Group 2 renders correctly 1`] = `
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <div
+        class="ecl-menu__site-name"
+      />
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -7968,1397 +6471,1025 @@ exports[`EC - Site Header Harmonised Group 2 renders correctly with extra attrib
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <div
+        class="ecl-menu__site-name"
+      />
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -9897,1397 +8028,1025 @@ exports[`EC - Site Header Harmonised Group 2 renders correctly with extra class 
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <div
+        class="ecl-menu__site-name"
+      />
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div

--- a/src/ec/packages/ec-component-site-header-harmonised/adapter.js
+++ b/src/ec/packages/ec-component-site-header-harmonised/adapter.js
@@ -66,7 +66,7 @@ const adapter = initialData => {
   delete adaptedData.searchForm;
 
   adaptedData.icon_file_path = defaultSprite;
-  adaptedData.menu_label = 'Menu';
+
   return adaptedData;
 };
 

--- a/src/ec/packages/ec-component-site-header-harmonised/adapter.js
+++ b/src/ec/packages/ec-component-site-header-harmonised/adapter.js
@@ -68,7 +68,7 @@ const adapter = initialData => {
   adaptedData.icon_file_path = defaultSprite;
   adaptedData.menu_label = 'Menu';
   adaptedData.site_name = 'Site name';
-  
+
   return adaptedData;
 };
 

--- a/src/ec/packages/ec-component-site-header-harmonised/ecl-site-header-harmonised.html.twig
+++ b/src/ec/packages/ec-component-site-header-harmonised/ecl-site-header-harmonised.html.twig
@@ -8,7 +8,6 @@
     - "banner" (string): Site name
     - "logged" (boolean): Whether the user is logged in or not
     - "menu" (boolean): Whether the component includes a menu
-    - "menu_label" (string): The menu toggler label
     - "site_name" (string): The site name (only used in group3)
     - "logo" (associative array) (default: predefined structure): Logo image settings. format:
         {

--- a/src/ec/packages/ec-component-site-header-standardised/__snapshots__/site-header-standardised.test.js.snap
+++ b/src/ec/packages/ec-component-site-header-standardised/__snapshots__/site-header-standardised.test.js.snap
@@ -167,1182 +167,1027 @@ exports[`EC - Site Header Standardised Default renders correctly 1`] = `
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Site name
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -1946,1182 +1791,1027 @@ exports[`EC - Site Header Standardised Default renders correctly when logged in 
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Site name
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -3695,1182 +3385,1027 @@ exports[`EC - Site Header Standardised Default renders correctly with extra attr
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Site name
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -5442,1182 +4977,1027 @@ exports[`EC - Site Header Standardised Default renders correctly with extra clas
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Close
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Site name
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Home  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Close
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Back
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Home  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 with a very long label going on 2 lines
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 with a very long label
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 with a long label
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 with a long label
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4 with a very long label
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -7189,1402 +6569,1027 @@ exports[`EC - Site Header Standardised Translated renders correctly 1`] = `
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Fermer
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Nom du site
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Accueil  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Fermer
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Retour
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Accueil  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 avec un long titre sur plusieurs lignes
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 avec un long titre
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 avec un long titre
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 avec un long titre
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -9158,1402 +8163,1027 @@ exports[`EC - Site Header Standardised Translated renders correctly with extra a
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Fermer
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Nom du site
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Accueil  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Fermer
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Retour
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Accueil  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 avec un long titre sur plusieurs lignes
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 avec un long titre
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 avec un long titre
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 avec un long titre
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div
@@ -11125,1402 +9755,1027 @@ exports[`EC - Site Header Standardised Translated renders correctly with extra c
     data-ecl-menu=""
   >
     <div
-      class="ecl-container"
+      class="ecl-menu__overlay"
+      data-ecl-menu-overlay=""
+    />
+    <div
+      class="ecl-container ecl-menu__container"
     >
       <a
-        class="ecl-link ecl-link--standalone ecl-menu__toggle"
-        data-ecl-menu-toggle=""
+        class="ecl-link ecl-link--standalone ecl-menu__open"
+        data-ecl-menu-open=""
         href="/example"
       >
-        <div
-          class="ecl-menu__toggle-open"
+        <svg
+          aria-hidden="true"
+          class="ecl-icon ecl-icon--s"
+          focusable="false"
         >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#general--hamburger"
-            />
-          </svg>
-          Menu
-        </div>
-        <div
-          class="ecl-menu__toggle-close"
-        >
-          <svg
-            aria-hidden="true"
-            class="ecl-icon ecl-icon--s"
-            focusable="false"
-          >
-            <use
-              xlink:href="/icons.svg#ui--close-filled"
-            />
-          </svg>
-          Fermer
-        </div>
+          <use
+            xlink:href="/icons.svg#general--hamburger"
+          />
+        </svg>
+        Menu
       </a>
       <div
         class="ecl-menu__site-name"
       >
         Nom du site
       </div>
-      <ul
-        class="ecl-menu__list"
-        data-ecl-menu-list=""
+      <section
+        class="ecl-menu__inner"
+        data-ecl-menu-inner=""
       >
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="false"
-          data-ecl-menu-item=""
+        <header
+          class="ecl-menu__inner-header"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <button
+            class="ecl-menu__close ecl-button ecl-button--text"
+            data-ecl-menu-close=""
+            type="submit"
           >
-            Accueil  
-          </a>
-        </li>
-        <li
-          class="ecl-menu__item ecl-menu__item--current"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link ecl-menu__link--current"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 1
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <span
+              class="ecl-menu__close-container ecl-button__container"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--close-filled"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label="true"
+              >
+                Fermer
+              </span>
+            </span>
+          </button>
           <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+            class="ecl-menu__title"
           >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem ecl-menu__subitem--current"
-              >
-                <a
-                  class="ecl-menu__sublink ecl-menu__sublink--current"
-                  href="/example"
-                >
-                  Item 1.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 1.16
-                </a>
-              </li>
-            </ul>
+            Menu
           </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
+          <button
+            class="ecl-menu__back ecl-button ecl-button--text"
+            data-ecl-menu-back=""
+            type="submit"
+          >
+            <span
+              class="ecl-button__container"
+            >
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--s ecl-icon--rotate-270 ecl-button__icon ecl-button__icon--before"
+                data-ecl-icon=""
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+              <span
+                class="ecl-button__label"
+                data-ecl-label=""
+              >
+                Retour
+              </span>
+            </span>
+          </button>
+        </header>
+        <ul
+          class="ecl-menu__list"
         >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+          <li
+            class="ecl-menu__item"
+            data-ecl-menu-item=""
           >
-            Item 2
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Accueil  
+            </a>
+          </li>
+          <li
+            class="ecl-menu__item ecl-menu__item--current"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link ecl-menu__link--current"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 2
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 2.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem ecl-menu__subitem--current"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink ecl-menu__sublink--current"
+                    href="/example"
+                  >
+                    Item 2.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 2.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 2.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 3
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 3
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 3.3
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 4
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.3 avec un long titre sur plusieurs lignes
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 3.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 3.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 4.14
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 4
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
+              Item 5
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
+              >
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 5.7
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            <ul
-              class="ecl-menu__sublist"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <li
-                class="ecl-menu__subitem"
+              Item 6
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 4.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
+            >
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.9 avec un long titre
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.10
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.11
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.12
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.13
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.14
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 4.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.15
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
+                >
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 6.16
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+          <li
+            class="ecl-menu__item"
+            data-ecl-has-children=""
+            data-ecl-menu-item=""
           >
-            Item 5
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
+            <a
+              class="ecl-menu__link"
+              data-ecl-menu-link=""
+              href="/example"
             >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
+              Item 7 avec un long titre
+              <svg
+                aria-hidden="true"
+                class="ecl-icon ecl-icon--xs ecl-icon--rotate-90 ecl-menu__link-icon"
+                focusable="false"
+              >
+                <use
+                  xlink:href="/icons.svg#ui--corner-arrow"
+                />
+              </svg>
+            </a>
+            <div
+              class="ecl-menu__mega"
+              data-ecl-menu-mega=""
             >
-              <li
-                class="ecl-menu__subitem"
+              <ul
+                class="ecl-menu__sublist"
               >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.1
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.2
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.3
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.4
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.5
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.6
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.7
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.8
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.9
+                  </a>
+                </li>
+                <li
+                  class="ecl-menu__subitem"
+                  data-ecl-menu-subitem=""
                 >
-                  Item 5.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 5.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 6
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 6.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-        <li
-          class="ecl-menu__item"
-          data-ecl-has-children="true"
-          data-ecl-menu-item=""
-        >
-          <a
-            class="ecl-menu__link"
-            data-ecl-menu-link=""
-            href="/example"
-          >
-            Item 7 avec un long titre
-            <svg
-              aria-hidden="true"
-              class="ecl-icon ecl-icon--xs ecl-icon--rotate-180 ecl-menu__link-icon"
-              focusable="false"
-            >
-              <use
-                xlink:href="/icons.svg#ui--corner-arrow"
-              />
-            </svg>
-          </a>
-          <div
-            class="ecl-menu__mega"
-            data-ecl-menu-mega=""
-          >
-            <ul
-              class="ecl-menu__sublist"
-            >
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.1
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.2
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.3
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.4
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.5
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.6
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.7
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.8
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.9
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.10
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.11
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.12
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.13
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.14
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.15
-                </a>
-              </li>
-              <li
-                class="ecl-menu__subitem"
-              >
-                <a
-                  class="ecl-menu__sublink"
-                  href="/example"
-                >
-                  Item 7.16
-                </a>
-              </li>
-            </ul>
-          </div>
-        </li>
-      </ul>
+                  <a
+                    class="ecl-menu__sublink"
+                    href="/example"
+                  >
+                    Item 7.10
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </section>
     </div>
   </nav>
   <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,6 +984,13 @@
 "@ecl-twig/data-utils@file:utils/data-utils":
   version "0.0.0-dev-only"
 
+"@ecl-twig/ec-component-menu@2.25.1":
+  version "2.25.1"
+  resolved "https://registry.yarnpkg.com/@ecl-twig/ec-component-menu/-/ec-component-menu-2.25.1.tgz#b973938d4a44b7b5b8ef916bcb3f27c82f84bfd3"
+  integrity sha512-qoTEcLKgd2/Eyjih1QV96KE9wwksc/xv6/40RAo39wFpGQm31Y9rzBrlmM8xArtpbCsIR5YsSe5STG3mLPQ9tw==
+  dependencies:
+    "@ecl-twig/ec-component-icon" "2.25.1"
+
 "@ecl-twig/php-storybook@file:php/php_storybook":
   version "0.0.1-alpha"
 
@@ -1009,6 +1016,11 @@
   version "2.25.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-base/-/ec-base-2.25.0.tgz#b379efb6d3fff0214458880ca42e248017183fa5"
   integrity sha512-Y5h//IUyq6yvQsy33daLq0PjzzSUcl0YhuipIzCwSIzHXIxvapbe6UHxJ1khczdQ+6onXdsRE4HEmipO4xfRHQ==
+
+"@ecl/ec-base@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-base/-/ec-base-2.26.0.tgz#f39e8ae8ba762bea09e1707d30781d52970d9411"
+  integrity sha512-dHSlRWEovovEWCXOZqZs/WjOXBZlmBlNvLLdlUqZppJ+B/4U9PrKDqQF2XktckGVATBfS9G7MPFQ5ueQ5pzCoQ==
 
 "@ecl/ec-component-accordion@2.25.0":
   version "2.25.0"
@@ -1061,6 +1073,14 @@
   dependencies:
     "@ecl/ec-base" "^2.25.0"
     "@ecl/ec-component-icon" "^2.25.0"
+
+"@ecl/ec-component-button@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-component-button/-/ec-component-button-2.26.0.tgz#0960b4f69f2bde1d9d792c7230d4d0f26c464820"
+  integrity sha512-XPZ+JvfEpTenMgQV+IGGEHb/XgT2dp6VafVofhCc39yWhQvuj1aQUS2qB+MTykQ0/BwszWpejj5pysJ07rsiJA==
+  dependencies:
+    "@ecl/ec-base" "^2.26.0"
+    "@ecl/ec-component-icon" "^2.26.0"
 
 "@ecl/ec-component-card@2.25.0":
   version "2.25.0"
@@ -1265,6 +1285,13 @@
   dependencies:
     "@ecl/ec-base" "^2.25.0"
 
+"@ecl/ec-component-icon@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-component-icon/-/ec-component-icon-2.26.0.tgz#0e0b7b7ca3a615ea0220006eba7edeb7bd31c716"
+  integrity sha512-harQI7rQM/wUwVxSFrMEffRgt6WBQtadGMVNQN3SZLJAM/JKsEtwtBkJQvS3upP8gUAx6sByOuqB1DPQSo/prA==
+  dependencies:
+    "@ecl/ec-base" "^2.26.0"
+
 "@ecl/ec-component-inpage-navigation@2.25.0":
   version "2.25.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-component-inpage-navigation/-/ec-component-inpage-navigation-2.25.0.tgz#4971688eb00f515324509cf5a9a8a2f565c421db"
@@ -1294,6 +1321,14 @@
     "@ecl/ec-base" "^2.25.0"
     "@ecl/ec-component-icon" "^2.25.0"
 
+"@ecl/ec-component-link@^2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-component-link/-/ec-component-link-2.26.0.tgz#2f2a0895ab0c61c7c2e86f64b4fbcead7008aa0d"
+  integrity sha512-SgIuF8G5aPzmVPqZO4129rPM9ZW0Jbc9balexG6roIhReu17IEcnsJZCmHd6IBPwu78bp0ypFzddm+xMMhyfdA==
+  dependencies:
+    "@ecl/ec-base" "^2.26.0"
+    "@ecl/ec-component-icon" "^2.26.0"
+
 "@ecl/ec-component-list@2.25.0":
   version "2.25.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-component-list/-/ec-component-list-2.25.0.tgz#d39dd3425aadd721836b7c6a41649f1d9c3a395b"
@@ -1317,14 +1352,17 @@
     "@ecl/ec-component-button" "^2.25.0"
     "@ecl/ec-component-link" "^2.25.0"
 
-"@ecl/ec-component-menu@2.25.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@ecl/ec-component-menu/-/ec-component-menu-2.25.0.tgz#0184b579a2cda314edb6a152d5c3e203430f2adf"
-  integrity sha512-bq0ZRRvXY0GCuh6GCmABCDa8UY2ljQffc4tWxMjbO/jY/rS0taojMNVEy/5EDWacAfEIp1wRC+VAJXjoPrj6Ng==
+"@ecl/ec-component-menu@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-component-menu/-/ec-component-menu-2.26.0.tgz#a4d79ea7c8c9551cacacaea800b968babbeebe16"
+  integrity sha512-b3PsI3cuTPoj+MXxLv02fvy8r7bPZep0e+S+UnrkbvSsbNW5QdNZkwwRqBkLCsmyt24nVAjar7Cu3QBh9OBsaA==
   dependencies:
-    "@ecl/ec-base" "^2.25.0"
-    "@ecl/ec-component-button" "^2.25.0"
-    "@ecl/ec-component-link" "^2.25.0"
+    "@ecl/ec-base" "^2.26.0"
+    "@ecl/ec-component-button" "^2.26.0"
+    "@ecl/ec-component-link" "^2.26.0"
+    mobile-device-detect "0.3.3"
+    stickyfilljs "2.1.0"
+    swipe-listener "1.1.0"
 
 "@ecl/ec-component-message@2.25.0":
   version "2.25.0"
@@ -1494,6 +1532,11 @@
   resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.25.0.tgz#47b1ab869029050f40839ccaaf34278a7840edb5"
   integrity sha512-emLWjsPFEMqyZPZJeM3scfarfjcNf/P32kzyEHNs2AopIUyS1GFZXtGBGk5Jrnc6NE4bUO32nyHamk72BV+GyA==
 
+"@ecl/ec-resources-icons@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.26.0.tgz#9f98c52fe2e8379b8e573c93a3dbf60a13e0e65c"
+  integrity sha512-q8UAtjw/BC7QgRKMULXk8U19Hfpn9D23r3JdR/mLn1BIizSGs1i83UOFelFskSpMW2laTiS6Cu2Hb/gRxxpBow==
+
 "@ecl/ec-resources-logo@2.25.0":
   version "2.25.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-resources-logo/-/ec-resources-logo-2.25.0.tgz#b70bc793101bf024ba850554c587ab552ea3c211"
@@ -1659,10 +1702,10 @@
   resolved "https://registry.yarnpkg.com/@ecl/ec-specs-menu-legacy/-/ec-specs-menu-legacy-2.25.0.tgz#7262549281c6522a3644253f8b474156f0629841"
   integrity sha512-JLSkQc2GVUnEQ+8f2iJoHmHeez/3VqkxJqMeiqC+sIwwXgiwhjcGs1c2XaIJ3RBtaVtBKhVr157tpLMiK94Ihg==
 
-"@ecl/ec-specs-menu@2.25.0":
-  version "2.25.0"
-  resolved "https://registry.yarnpkg.com/@ecl/ec-specs-menu/-/ec-specs-menu-2.25.0.tgz#efe96b96ab4a7e34316d6bd320a788b11e28c3e9"
-  integrity sha512-bAzNQRtfEnSKa4U6G2YMiL1OA4gW0kfO8RsPWzF4tcL3aHWbuZIWkYbJoJewuQ0DYH6fat97NOhD/XDDm7PKOg==
+"@ecl/ec-specs-menu@2.26.0":
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-specs-menu/-/ec-specs-menu-2.26.0.tgz#8538291979b96e17d486a6269903ea0655c7f80e"
+  integrity sha512-o0dcs25TgWJx2S2VN+B32B7/IHQL5OoGV/ocvKj6rg3XC1vKHRPxsV17ENYGXuSVUt9Ze0ynUOq0+O4ZW0D0pg==
 
 "@ecl/ec-specs-message@2.25.0":
   version "2.25.0"
@@ -12765,6 +12808,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mobile-device-detect@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/mobile-device-detect/-/mobile-device-detect-0.3.3.tgz#6880f54c2e838d8dccbfc0d962d01a348db5faad"
+  integrity sha512-JOrQ2mwcBnEz/6hyvP/aXI8R03DnlwlQey7cukE6kCy9RLQbzchN5yMocEXuOw4NXdCsU6k7mEAolHwLxgPYwQ==
+
 modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
@@ -16758,6 +16806,11 @@ supports-hyperlinks@^1.0.1:
   dependencies:
     has-flag "^2.0.0"
     supports-color "^5.0.0"
+
+swipe-listener@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/swipe-listener/-/swipe-listener-1.1.0.tgz#f56bbe1efad3a4d91a1f5df3d03747201fca9a03"
+  integrity sha512-89mLHgoTejI2I1/oK6x8OGov6fwK6ujcSb8is8yWHo9txBOpm4a6k06MUUr7WNFvMMHYgY50IPRMxSk7ce43TQ==
 
 symbol-observable@^1.0.3, symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
# PR description

To reproduce the diff with the ECL markup:
render the component
`yarn check:component ec menu`
run the ecl-diff script:
`yarn ecl-diff ec`

the choiches you have to make are:
- "menu as the component
- "en" as the twig variant
- choose "navigation" from the subsections
You get it ;)

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
