### PR TITLE
fix(pre-commit): Different approach for combining husky and grump-php - FRONT-960

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ php/images
 yarn-error.log
 .idea
 composer.lock
+grump-report.txt

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     "grump-en": [
       "echo \"php ./vendor/bin/grumphp git:pre-commit\" >> .git/hooks/pre-commit"
     ],
-    "twig-cs": "./vendor/bin/twigcs ./src/*/packages",
+    "twig-cs": "./vendor/bin/twigcs \"./src/*/packages\"",
     "cs": "./vendor/bin/twigcs",
     "grump-cs": "php ./vendor/bin/grumphp run",
     "grump-dis": "./scripts/grump-dis.sh"
   },
   "require-dev": {
-    "friendsoftwig/twigcs": "^3.1.3",
-    "phpro/grumphp": "^0.16.1"
+    "friendsoftwig/twigcs": "^3.2.2",
+    "phpro/grumphp": "^0.18.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,9 @@
     "storybook"
   ],
   "scripts": {
-    "grump-en": [
-      "echo \"php ./vendor/bin/grumphp git:pre-commit\" >> .git/hooks/pre-commit"
-    ],
     "twig-cs": "./vendor/bin/twigcs \"./src/*/packages\"",
-    "cs": "./vendor/bin/twigcs",
-    "grump-cs": "php ./vendor/bin/grumphp run",
-    "grump-dis": "./scripts/grump-dis.sh"
+    "cs": "./vendor/bin/twigcs --severity error",
+    "grump-cs": "php ./vendor/bin/grumphp run"
   },
   "require-dev": {
     "friendsoftwig/twigcs": "^3.2.2",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -64,7 +64,7 @@ yarn lint
 The libraries we use for sniffing and linting the twig templates all are php ones, therefore in order to be able to use the functionality in ECl-twig you would need a working installation of php (7.x) and composer to be installed.
 
 ```bash
-composer install --no-scripts && composer grump-en
+composer install --no-scripts
 ```
 
 We install the libraries with the no-scripts flag in order to avoid the override of the git hooks created by husky.
@@ -73,13 +73,13 @@ To circumvent the issue we added a script and we suggest you to run it together 
 the grump-php pre-commit hook by running:
 
 ```bash
-composer grump-en
+yarn grump-en
 ```
 
 To disable the pre-commit execution of the grump-php sniff you run:
 
 ```bash
-composer grump-dis
+yarn grump-dis
 ```
 
 You can also run the sniffer manually on the code in different ways using the command line:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "deploy:php": "gh-pages -d php/dist",
     "diff": "node_modules/@ecl-twig/php-storybook/scripts/diff.js",
     "ecl-diff": "node_modules/@ecl-twig/php-storybook/scripts/ecl-diff.js --interactive",
+    "grump-dis": "./scripts/grump-dis.js",
+    "grump-en": "./scripts/grump-en.js",
     "jest": "jest",
     "jest:update": "jest -u",
     "lint:js": "eslint .",

--- a/scripts/grump-dis.js
+++ b/scripts/grump-dis.js
@@ -3,7 +3,6 @@
 /* eslint-disable import/no-extraneous-dependencies, no-console */
 
 const { ncp } = require('ncp');
-const fs = require('fs');
 
 const options = {};
 options.dereference = true;

--- a/scripts/grump-dis.js
+++ b/scripts/grump-dis.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/* eslint-disable import/no-extraneous-dependencies, no-console */
+
+const { ncp } = require('ncp');
+const fs = require('fs');
+
+const options = {};
+options.dereference = true;
+
+ncp('scripts/pre-commit.husky', '.git/hooks/pre-commit', options, err => {
+  if (err) {
+    return console.error(err);
+  }
+  return console.log('Grumphp pre-commit disabled.');
+});

--- a/scripts/grump-dis.sh
+++ b/scripts/grump-dis.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-sed -i.bak "/php .\/vendor\/bin\/grumphp/d" .git/hooks/pre-commit

--- a/scripts/grump-en.js
+++ b/scripts/grump-en.js
@@ -3,7 +3,6 @@
 /* eslint-disable import/no-extraneous-dependencies, no-console */
 
 const { ncp } = require('ncp');
-const fs = require('fs');
 
 const options = {};
 options.dereference = true;

--- a/scripts/grump-en.js
+++ b/scripts/grump-en.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/* eslint-disable import/no-extraneous-dependencies, no-console */
+
+const { ncp } = require('ncp');
+const fs = require('fs');
+
+const options = {};
+options.dereference = true;
+
+ncp('scripts/pre-commit.combined', '.git/hooks/pre-commit', options, err => {
+  if (err) {
+    return console.error(err);
+  }
+  return console.log('Pre-commit hook overridden.');
+});

--- a/scripts/pre-commit.combined
+++ b/scripts/pre-commit.combined
@@ -1,0 +1,7 @@
+#!/bin/sh
+# husky & Grump-php
+
+export GRUMPHP_GIT_WORKING_DIR=$(git rev-parse --show-toplevel)
+if 'exec' 'vendor/phpro/grumphp/bin/grumphp' 'git:pre-commit'; then
+  . "$(dirname "$0")/husky.sh"
+fi

--- a/scripts/pre-commit.combined
+++ b/scripts/pre-commit.combined
@@ -1,7 +1,12 @@
 #!/bin/sh
-# husky & Grump-php
+# husky & grump-php
 
 export GRUMPHP_GIT_WORKING_DIR=$(git rev-parse --show-toplevel)
-if 'exec' 'vendor/phpro/grumphp/bin/grumphp' 'git:pre-commit'; then
+report='grump-report.txt'
+test='exec' 'composer' 'grump-cs' > $report;
+cat $report
+if grep -q "ERROR" $report; then
+  exit 1
+else
   . "$(dirname "$0")/husky.sh"
 fi

--- a/scripts/pre-commit.husky
+++ b/scripts/pre-commit.husky
@@ -1,0 +1,8 @@
+#!/bin/sh
+# husky
+
+# Created by Husky v4.2.3 (https://github.com/typicode/husky#readme)
+#   At: 3/30/2020, 11:23:07 AM
+#   From: /home/planctus/projects/INNO/ecl-twig/node_modules/husky (https://github.com/typicode/husky#readme)
+
+. "$(dirname "$0")/husky.sh"

--- a/src/ec/packages/ec-component-site-header-harmonised/ecl-site-header-harmonised.html.twig
+++ b/src/ec/packages/ec-component-site-header-harmonised/ecl-site-header-harmonised.html.twig
@@ -80,27 +80,27 @@
 {% set _css_class = 'ecl-site-header-harmonised ecl-site-header-harmonised--' ~ _group %}
 
 {% if search_form is defined and search_form is not empty %}
-  {% set _search_form = {
-    text_input: {
+{% set _search_form = {
+  text_input: {
+    name: 'search',
+    extra_classes: 'ecl-search-form__text-input'
+  },
+  button: {
+    variant: 'search',
+    icon: {
+      type: 'general',
       name: 'search',
-      extra_classes: 'ecl-search-form__text-input'
+      path: _icon_file_path,
+      size: 'fluid',
     },
-    button: {
-      variant: 'search',
-      icon: {
-        type: 'general',
-        name: 'search',
-        path: _icon_file_path,
-        size: 'fluid',
-      },
-      extra_classes: 'ecl-search-form__button'
-    },
-    extra_attributes: [
-    { name: 'data-ecl-search-form' }
-    ]|merge(search_form.extra_attributes|default({})),
-    extra_classes: 'ecl-site-header-harmonised__search'
-  }
-  %}
+    extra_classes: 'ecl-search-form__button'
+  },
+  extra_attributes: [
+  { name: 'data-ecl-search-form' }
+  ]|merge(search_form.extra_attributes|default({})),
+  extra_classes: 'ecl-site-header-harmonised__search'
+}
+%}
 {% endif %}
 
 {# Merge options #}


### PR DESCRIPTION
# PR description

Please drop a few lines about the PR: what it does, how to test it, etc.

## QA Checklist

So, the logic here is:
We now have a way to combine grumphp and husky, we first execute grump-php and basing on its output we run or not the husky pre-commit script.
This way we prevent the commit from happening when there is an issue in one of our templates, the whole library is checked and not only the "staged" files which would normally happen using the pre-commit hook provided by grump-php, but the total number of files to be checked is really small, so it's not a performance issue.
The grump-en and grump-dis scripts have been replaced by node scripts and can be executed through yarn, the documentation has been updated.
To configure you environment:
`composer update`
`yarn grump-en`

Should be enough, you should now see your commit "failing" if you modify any twig template introducing a violation (like a space at the end of a line, two spaces, whatever) while if you then fix it you should see the green output by grump-php plus the checks by husky.
When it fails it should show the output of the twigcs script, unfortunately in this version is not possible to limit the output to "errors" and we receive lots of warnings that are false positive.
I briefly tested the 4.0 version of twigcs which is still in beta, it spots apparently many violations in our templates, we might soon move to that where we will also be able to set the twig version to check the code against.

This solution is using grep, hope it's not an issue for the current developers.
The changes in the site header template are the result of this implementation, grump-php was "failing" due to that.



- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
