### PR TITLE
fix(radio): Initializing local _extra_attributes variable - FRONT-1144

### DIFF
--- a/src/ec/packages/ec-component-radio/ecl-radio-button.html.twig
+++ b/src/ec/packages/ec-component-radio/ecl-radio-button.html.twig
@@ -35,6 +35,7 @@
 {% set _label_css_class = 'ecl-radio__label' %}
 {% set _helper_css_class = 'ecl-radio__help' %}
 {% set _box_css_class = 'ecl-radio__box' %}
+{% set _extra_attributes = '' %}
 
 {# Internal logic - Process properties #}
 


### PR DESCRIPTION
# PR description

Please drop a few lines about the PR: what it does, how to test it, etc.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
