### PR TITLE
chore(eslint): fix linting rules - noissue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,33 +16,26 @@ module.exports = {
   rules: {
     'unicorn/prevent-abbreviations': 0,
     'unicorn/prefer-node-append': 0,
+    'import/no-extraneous-dependencies': 0,
   },
   overrides: [
     {
       files: '**/demo/*.js',
       rules: {
         'unicorn/filename-case': 'off',
-        'import/no-extraneous-dependencies': 0,
       },
     },
     {
-      files: ['src/**/*.{story,test}.js'],
+      files: ['src/**/*.{story,test}.js', 'src/**/packages/**/adapter.js'],
       rules: {
-        'import/no-extraneous-dependencies': 0,
+        'no-param-reassign': 0,
       },
     },
     {
       files: ['php/**/*.story.js'],
       rules: {
-        'import/no-extraneous-dependencies': 0,
         camelcase: 0,
         'import/order': 0,
-      },
-    },
-    {
-      files: ['utils/**/*.{js,jsx}'],
-      rules: {
-        'import/no-extraneous-dependencies': 0,
       },
     },
   ],

--- a/src/ec/packages/ec-component-accordion/accordion.story.js
+++ b/src/ec/packages/ec-component-accordion/accordion.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-accordion/accordion.test.js
+++ b/src/ec/packages/ec-component-accordion/accordion.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import demoData from './demo/data';

--- a/src/ec/packages/ec-component-accordion2/accordion2.story.js
+++ b/src/ec/packages/ec-component-accordion2/accordion2.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-accordion2/accordion2.test.js
+++ b/src/ec/packages/ec-component-accordion2/accordion2.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import demoData from './demo/data';

--- a/src/ec/packages/ec-component-blockquote/blockquote.story.js
+++ b/src/ec/packages/ec-component-blockquote/blockquote.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign, no-shadow */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-breadcrumb-core/breadcrumb-core.story.js
+++ b/src/ec/packages/ec-component-breadcrumb-core/breadcrumb-core.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, text, select } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-breadcrumb-harmonised/breadcrumb-harmonised.story.js
+++ b/src/ec/packages/ec-component-breadcrumb-harmonised/breadcrumb-harmonised.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import withCode from '@ecl-twig/storybook-addon-code';

--- a/src/ec/packages/ec-component-breadcrumb-standardised/breadcrumb-standardised.story.js
+++ b/src/ec/packages/ec-component-breadcrumb-standardised/breadcrumb-standardised.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import withCode from '@ecl-twig/storybook-addon-code';

--- a/src/ec/packages/ec-component-button/button.story.js
+++ b/src/ec/packages/ec-component-button/button.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select, boolean } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-card/card.story.js
+++ b/src/ec/packages/ec-component-card/card.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, text, array, button } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-checkbox/checkbox.story.js
+++ b/src/ec/packages/ec-component-checkbox/checkbox.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-contextual-navigation/contextual-navigation.story.js
+++ b/src/ec/packages/ec-component-contextual-navigation/contextual-navigation.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, number } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-date-block/date-block.story.js
+++ b/src/ec/packages/ec-component-date-block/date-block.story.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign, no-shadow */
+/* eslint-disable no-shadow */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-date-block/date-block.test.js
+++ b/src/ec/packages/ec-component-date-block/date-block.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import demoData from './demo/data';

--- a/src/ec/packages/ec-component-datepicker/datepicker.story.js
+++ b/src/ec/packages/ec-component-datepicker/datepicker.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, text, select } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-datepicker/datepicker.test.js
+++ b/src/ec/packages/ec-component-datepicker/datepicker.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import demoData from './demo/data';

--- a/src/ec/packages/ec-component-description-list/description-list.story.js
+++ b/src/ec/packages/ec-component-description-list/description-list.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, select, text } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-expandable/expandable.story.js
+++ b/src/ec/packages/ec-component-expandable/expandable.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-fact-figures/fact-figures.story.js
+++ b/src/ec/packages/ec-component-fact-figures/fact-figures.story.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign, camelcase */
+/* eslint-disable camelcase */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, boolean, text, button } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-file-upload/file-upload.story.js
+++ b/src/ec/packages/ec-component-file-upload/file-upload.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select, boolean } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-file/file.story.js
+++ b/src/ec/packages/ec-component-file/file.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-footer-core/footer-core.story.js
+++ b/src/ec/packages/ec-component-footer-core/footer-core.story.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign, no-shadow */
+/* eslint-disable no-shadow */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import withCode from '@ecl-twig/storybook-addon-code';

--- a/src/ec/packages/ec-component-footer-harmonised/footer-harmonised.story.js
+++ b/src/ec/packages/ec-component-footer-harmonised/footer-harmonised.story.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign, no-shadow */
+/* eslint-disable no-shadow */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, button, text } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-footer-standardised/footer-standardised.story.js
+++ b/src/ec/packages/ec-component-footer-standardised/footer-standardised.story.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign, no-shadow */
+/* eslint-disable no-shadow */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import withCode from '@ecl-twig/storybook-addon-code';

--- a/src/ec/packages/ec-component-gallery/gallery.story.js
+++ b/src/ec/packages/ec-component-gallery/gallery.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-hero-banner/hero-banner.story.js
+++ b/src/ec/packages/ec-component-hero-banner/hero-banner.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-inpage-navigation/inpage-navigation.story.js
+++ b/src/ec/packages/ec-component-inpage-navigation/inpage-navigation.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, button } from '@storybook/addon-knobs';
 import { loremIpsum } from 'lorem-ipsum';

--- a/src/ec/packages/ec-component-inpage-navigation/inpage-navigation.test.js
+++ b/src/ec/packages/ec-component-inpage-navigation/inpage-navigation.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import demoData from './demo/data';

--- a/src/ec/packages/ec-component-language-list/language-list.story.js
+++ b/src/ec/packages/ec-component-language-list/language-list.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-link/link.story.js
+++ b/src/ec/packages/ec-component-link/link.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-media-container/media-container.story.js
+++ b/src/ec/packages/ec-component-media-container/media-container.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import he from 'he';
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select, object } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-menu-legacy/menu-legacy.test.js
+++ b/src/ec/packages/ec-component-menu-legacy/menu-legacy.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import defaultDataStructure from './demo/data';

--- a/src/ec/packages/ec-component-menu/menu.story.js
+++ b/src/ec/packages/ec-component-menu/menu.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, select, text, object } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-message/message.story.js
+++ b/src/ec/packages/ec-component-message/message.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-ordered-list/ordered-list.story.js
+++ b/src/ec/packages/ec-component-ordered-list/ordered-list.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, text } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-page-banner/page-banner.story.js
+++ b/src/ec/packages/ec-component-page-banner/page-banner.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, text, boolean, select } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-page-header-core/page-header-core.story.js
+++ b/src/ec/packages/ec-component-page-header-core/page-header-core.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, object } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-page-header-harmonised/page-header-harmonised.story.js
+++ b/src/ec/packages/ec-component-page-header-harmonised/page-header-harmonised.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, object } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-page-header-standardised/page-header-standardised.story.js
+++ b/src/ec/packages/ec-component-page-header-standardised/page-header-standardised.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, object } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-page-header/adapter.js
+++ b/src/ec/packages/ec-component-page-header/adapter.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import breadcrumbDataSimple from '../ec-component-breadcrumb/demo/data--simple';
 
 function formatPageHeaderInfo(i) {

--- a/src/ec/packages/ec-component-page-header/page-header.story.js
+++ b/src/ec/packages/ec-component-page-header/page-header.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import {
   withKnobs,

--- a/src/ec/packages/ec-component-pagination/pagination.story.js
+++ b/src/ec/packages/ec-component-pagination/pagination.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-radio/radio.story.js
+++ b/src/ec/packages/ec-component-radio/radio.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, boolean } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-search-form/search-form.story.js
+++ b/src/ec/packages/ec-component-search-form/search-form.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-select/select.story.js
+++ b/src/ec/packages/ec-component-select/select.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-site-header-core/site-header-core.story.js
+++ b/src/ec/packages/ec-component-site-header-core/site-header-core.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import {
   withKnobs,

--- a/src/ec/packages/ec-component-site-header-harmonised/site-header-harmonised.story.js
+++ b/src/ec/packages/ec-component-site-header-harmonised/site-header-harmonised.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import {
   withKnobs,

--- a/src/ec/packages/ec-component-site-header-standardised/site-header-standardised.story.js
+++ b/src/ec/packages/ec-component-site-header-standardised/site-header-standardised.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import {
   withKnobs,

--- a/src/ec/packages/ec-component-site-header/site-header.story.js
+++ b/src/ec/packages/ec-component-site-header/site-header.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import merge from 'deepmerge';
 import { storiesOf } from '@storybook/html';
 import { withKnobs, button } from '@storybook/addon-knobs';

--- a/src/ec/packages/ec-component-skip-link/skip-link.story.js
+++ b/src/ec/packages/ec-component-skip-link/skip-link.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, button } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-social-media-follow/social-media-follow.story.js
+++ b/src/ec/packages/ec-component-social-media-follow/social-media-follow.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-social-media-share/social-media-share.story.js
+++ b/src/ec/packages/ec-component-social-media-share/social-media-share.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-table/table.story.js
+++ b/src/ec/packages/ec-component-table/table.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { getExtraKnobs, tabLabels } from '@ecl-twig/story-utils';

--- a/src/ec/packages/ec-component-tag/tag.story.js
+++ b/src/ec/packages/ec-component-tag/tag.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-text-area/text-area.story.js
+++ b/src/ec/packages/ec-component-text-area/text-area.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-text-input/text-input.story.js
+++ b/src/ec/packages/ec-component-text-input/text-input.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withKnobs } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-timeline/timeline.story.js
+++ b/src/ec/packages/ec-component-timeline/timeline.story.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign,prefer-destructuring */
+/* eslint-disable prefer-destructuring */
 import { storiesOf } from '@storybook/html';
 import { withKnobs, number, text, select } from '@storybook/addon-knobs';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';

--- a/src/ec/packages/ec-component-timeline/timeline.test.js
+++ b/src/ec/packages/ec-component-timeline/timeline.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { merge, renderTwigFileAsNode } from '@ecl-twig/test-utils';
 
 import demoData from './demo/data';

--- a/src/ec/packages/ec-component-unordered-list/unordered-list.story.js
+++ b/src/ec/packages/ec-component-unordered-list/unordered-list.story.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import { storiesOf } from '@storybook/html';
 import { withNotes } from '@ecl-twig/storybook-addon-notes';
 import { withKnobs, select, text } from '@storybook/addon-knobs';


### PR DESCRIPTION
Removed an obvious repetition and needless copy-paste of rules in story files and adapters.
Hoisted needlessly repeated ignore rule from sub-patterns to a global one.