### PR TITLE
feat(gallery): Component and resources updates for v2.29.0 - FRONT-1222

### DIFF
--- a/src/ec/.storybook/preview-head.html
+++ b/src/ec/.storybook/preview-head.html
@@ -1,26 +1,26 @@
 <link
   rel="stylesheet"
-  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.28.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website.css"
-  integrity="sha256-6GMzZCl8zF833qxOT26iQHv8AgDRj03sHILujzyVNRc=
-  sha384-l2+DR/d2HILWzttYRAGfCRq+bnCMPdagszNiyL2hyxkg5SBsPjQY4a1F6lOewgv1
-  sha512-/Xrr0TwTm3qLahciQJSuuLJ8i3ydwXlltyv5siXsfeq1LH+CiXCUhCJeWdM+0BD5MYkZRBYzUZUupN00VoFx3g=="
+  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.29.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website.css"
+  integrity="sha256-f2iErMHhPaFGuNthLhb5WEhyo2xmygexbizsqConYL0=
+  sha384-kot8sxhbq4IbFTidQTC8BuJ1cNc0QcLFololGAQVKnBVH0g66WR+R/gQuZkKVB4g
+  sha512-gJj7BL4U0dkqCQUSlzyK/mGDPucPsea1ApqrIW0+X8Y5boFIxAzYWskXjFEeRd0oyCpRKnK/PUA6/Gy1u+/20A=="
   crossorigin="anonymous"
   media="screen"
 />
 <link
   rel="stylesheet"
-  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.28.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website-print.css"
-  integrity="sha256-ggHGwQUF7yGCCwFw72lZMdLhXNvogBjBEz/Po8TQSxo=
-  sha384-QcnUBXIft4mv7lAlXMcU93RD0D1omBIuBtVhcfkJQwRaRunK4+f5+dHtBp7gasZD
-  sha512-4ikPF1rjskCg680kZdh5OW2I/opmnhzT/VMtjiI9FWsvMW846eTnHlZtUCZekxnmXS8dYuC2iLcyvQVouWFd6A=="
+  href="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.29.0/ec-preset-legacy-website/styles/ecl-ec-preset-legacy-website-print.css"
+  integrity="sha256-F2qUzT9VLcOuL9GN/vPEHUIoQSg9pWizPpzJauIX2z8=
+  sha384-bzUDqvwgpMR/huWgU3kueK6D63CZ4MbpbWcJ5PvXJkzbd3ttiNO3e0CdCZz5sLdz
+  sha512-Tup9Dt2s9p4Al1vlR6GpmNQ5wljuj20LPFVGDor8Q47/k1RKOfBGPFXKS8ABjXHG1v7jmOJiHzQvNf2PeC+jdA=="
   crossorigin="anonymous"
   media="print"
 />
 <script
-  src="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.28.0/ec-preset-legacy-website/scripts/ecl-ec-preset-legacy-website.js"
-  integrity="sha256-2B+g0IcAEtT6w/l4kfC+IAjfsgAG0NgdXc0mK/guX5E=
-  sha384-1hSlLUruEfsOfwbtpMT2mXGuaDvEfs5N1SLQLFb0afcAzAMaCUCwKrsqr5T0iJea
-  sha512-F0VrGeGvgA6nBextFZu6d3FBfru83/b1YxlNr4hNnW9drrF4CBzWd7SNvquYZiXEhLMzV/BVSi0GP0st1fhnuA=="
+  src="https://cdn1.fpfis.tech.ec.europa.eu/ecl/v2.29.0/ec-preset-legacy-website/scripts/ecl-ec-preset-legacy-website.js"
+  integrity="sha256-axHUBVLGspLiJxp/FQPOMyHd2SIFDz1qJDlJdLjFnf8=
+  sha384-mHSmPF+Vdi0eS8LXmFbVPf/IvsFh0prhKeD9lvFpqY7GU7xd9fKn2iVNTkpK6pp5
+  sha512-ApIrXmjyVSsx6BSQkZ2IYVo5u2Ru8vWOP0Kb19/6FvMQU3PcFV4vDbDzr0AoM4yeF15dTTTP5C0AcuqQIUAORQ=="
   crossorigin="anonymous"
 ></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.8.3/polyfill.min.js"></script>

--- a/src/ec/packages/ec-component-gallery/README.md
+++ b/src/ec/packages/ec-component-gallery/README.md
@@ -22,6 +22,8 @@ npm install --save @ecl-twig/ec-component-gallery
   - "meta" (string) (default: '')
   - "icon" (object) (default: {}): object of type icon
   - "share_path" (string) (default: '')
+- **"view_all_label"** (string) (default: '') Label of the view all button
+- **"counter_label"** (string) (default: '') Label of the counter
 - **"selected_item_id"** (int) (default: 0)
 - **"extra_classes"** (optional) (string) (default: '') Extra classes (space separated)
 - **"extra_attributes"** (optional) (array) (default: []) Extra attributes
@@ -33,6 +35,8 @@ npm install --save @ecl-twig/ec-component-gallery
 <!-- prettier-ignore -->
 ```twig
 {% include '@ecl-twig/ec-component-gallery/ecl-gallery.html.twig' with {  
+  view_all_label: 'View all', 
+  counter_label: 'Media files in this gallery' , 
   items: [ 
     { 
       path: 'path/to/image.jpg', 

--- a/src/ec/packages/ec-component-gallery/__snapshots__/gallery.test.js.snap
+++ b/src/ec/packages/ec-component-gallery/__snapshots__/gallery.test.js.snap
@@ -422,7 +422,7 @@ exports[`EC - Gallery Default renders correctly 1`] = `
     >
       0
     </strong>
-    Media files in this gallery
+     Media files in this gallery
   </div>
   <button
     class="ecl-button ecl-button--ghost"
@@ -1033,7 +1033,7 @@ exports[`EC - Gallery Default renders correctly with extra attributes 1`] = `
     >
       0
     </strong>
-    Media files in this gallery
+     Media files in this gallery
   </div>
   <button
     class="ecl-button ecl-button--ghost"
@@ -1642,7 +1642,7 @@ exports[`EC - Gallery Default renders correctly with extra class names 1`] = `
     >
       0
     </strong>
-    Media files in this gallery
+     Media files in this gallery
   </div>
   <button
     class="ecl-button ecl-button--ghost"

--- a/src/ec/packages/ec-component-gallery/__snapshots__/gallery.test.js.snap
+++ b/src/ec/packages/ec-component-gallery/__snapshots__/gallery.test.js.snap
@@ -414,6 +414,23 @@ exports[`EC - Gallery Default renders correctly 1`] = `
       </a>
     </li>
   </ul>
+  <div
+    class="ecl-gallery__info"
+  >
+    <strong
+      data-ecl-gallery-count=""
+    >
+      0
+    </strong>
+    Media files in this gallery
+  </div>
+  <button
+    class="ecl-button ecl-button--ghost"
+    data-ecl-gallery-all=""
+    type="submit"
+  >
+    View all
+  </button>
   <dialog
     class="ecl-gallery__overlay"
     data-ecl-gallery-overlay=""
@@ -425,7 +442,7 @@ exports[`EC - Gallery Default renders correctly 1`] = `
       <button
         class="ecl-button ecl-button--ghost ecl-gallery__close-button"
         data-ecl-gallery-close=""
-        type="button"
+        type="submit"
       >
         <span
           class="ecl-button__container"
@@ -1008,6 +1025,23 @@ exports[`EC - Gallery Default renders correctly with extra attributes 1`] = `
       </a>
     </li>
   </ul>
+  <div
+    class="ecl-gallery__info"
+  >
+    <strong
+      data-ecl-gallery-count=""
+    >
+      0
+    </strong>
+    Media files in this gallery
+  </div>
+  <button
+    class="ecl-button ecl-button--ghost"
+    data-ecl-gallery-all=""
+    type="submit"
+  >
+    View all
+  </button>
   <dialog
     class="ecl-gallery__overlay"
     data-ecl-gallery-overlay=""
@@ -1019,7 +1053,7 @@ exports[`EC - Gallery Default renders correctly with extra attributes 1`] = `
       <button
         class="ecl-button ecl-button--ghost ecl-gallery__close-button"
         data-ecl-gallery-close=""
-        type="button"
+        type="submit"
       >
         <span
           class="ecl-button__container"
@@ -1600,6 +1634,23 @@ exports[`EC - Gallery Default renders correctly with extra class names 1`] = `
       </a>
     </li>
   </ul>
+  <div
+    class="ecl-gallery__info"
+  >
+    <strong
+      data-ecl-gallery-count=""
+    >
+      0
+    </strong>
+    Media files in this gallery
+  </div>
+  <button
+    class="ecl-button ecl-button--ghost"
+    data-ecl-gallery-all=""
+    type="submit"
+  >
+    View all
+  </button>
   <dialog
     class="ecl-gallery__overlay"
     data-ecl-gallery-overlay=""
@@ -1611,7 +1662,7 @@ exports[`EC - Gallery Default renders correctly with extra class names 1`] = `
       <button
         class="ecl-button ecl-button--ghost ecl-gallery__close-button"
         data-ecl-gallery-close=""
-        type="button"
+        type="submit"
       >
         <span
           class="ecl-button__container"

--- a/src/ec/packages/ec-component-gallery/demo/data.js
+++ b/src/ec/packages/ec-component-gallery/demo/data.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import specData from '@ecl/ec-specs-gallery/demo/data';
 
 const defaultSprite = '/static/icons.svg';
@@ -89,6 +88,8 @@ const data = {
     download: formatLink(specData.overlay.download),
     share: formatLink(specData.overlay.share),
   },
+  view_all_label: specData.viewAllLabel,
+  counter_label: specData.counterLabel,
 };
 
 data.overlay.download.link.path = '/example';

--- a/src/ec/packages/ec-component-gallery/ecl-gallery-overlay.html.twig
+++ b/src/ec/packages/ec-component-gallery/ecl-gallery-overlay.html.twig
@@ -49,7 +49,7 @@
     {% include '@ecl-twig/ec-component-button/ecl-button.html.twig' with _overlay.close|merge({
       extra_classes: 'ecl-gallery__close-button',
       variant: _button_variant,
-      type: _button_type,
+      type: 'submit',
       extra_attributes: [
         { name: 'data-ecl-gallery-close' },
       ],
@@ -107,7 +107,7 @@
       (_overlay.download.link is defined and _overlay.download.link is not empty) %}
       {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with _overlay.download|merge({
         link: {
-          icon_position: 'after',
+          icon_position: 'after'
         }|merge(_overlay.download.link),
         icon: _overlay.download.icon|merge({
           name: 'download',

--- a/src/ec/packages/ec-component-gallery/ecl-gallery.html.twig
+++ b/src/ec/packages/ec-component-gallery/ecl-gallery.html.twig
@@ -75,8 +75,7 @@
     {% endfor %}
   </ul>
   <div class="ecl-gallery__info">
-    <strong data-ecl-gallery-count>0</strong>
-    {{- _counter_label -}}
+    <strong data-ecl-gallery-count>0</strong> {{ _counter_label -}}
   </div>
 
   {% include '@ecl-twig/ec-component-button/ecl-button.html.twig' with {

--- a/src/ec/packages/ec-component-gallery/ecl-gallery.html.twig
+++ b/src/ec/packages/ec-component-gallery/ecl-gallery.html.twig
@@ -2,6 +2,8 @@
 
 {#
   Parameters:
+  - "counter_label" (string) (default: '') Label of the counter
+  - "view_all_label" (string) (default: '') Label of the view all button
   - "overlay" (object) (default: {})
     - "close" (object) (default: {}): object of type button
     - "previous" (object) (default: {}): object of type button
@@ -28,6 +30,8 @@
 {% set _css_class = 'ecl-gallery' %}
 {% set _extra_attributes = '' %}
 {% set _overlay = overlay|default({}) %}
+{% set _counter_label = counter_label|default('') %}
+{% set _view_all_label = view_all_label|default('') %}
 {% set _items = items|default([]) %}
 {% set _selected_item_id = selected_item_id|default(0) %}
 {% set _extra_attributes = 'data-ecl-auto-init="Gallery"' %}
@@ -70,6 +74,17 @@
       } only %}
     {% endfor %}
   </ul>
+  <div class="ecl-gallery__info">
+    <strong data-ecl-gallery-count>0</strong>
+    {{- _counter_label -}}
+  </div>
+
+  {% include '@ecl-twig/ec-component-button/ecl-button.html.twig' with {
+    label: _view_all_label,
+    type: 'submit',
+    variant: 'ghost',
+    extra_attributes: [{ name: 'data-ecl-gallery-all' }]
+  } only %}
 
   {% set _selected_item = {} %}
   {% if _items[_selected_item_id] is defined and _items[_selected_item_id] is not empty %}

--- a/src/ec/packages/ec-component-gallery/package.json
+++ b/src/ec/packages/ec-component-gallery/package.json
@@ -2,7 +2,7 @@
   "name": "@ecl-twig/ec-component-gallery",
   "author": "European Commission",
   "license": "EUPL-1.1",
-  "version": "2.28.1",
+  "version": "2.29.0",
   "description": "ECL Twig - EC Gallery",
   "publishConfig": {
     "access": "public"
@@ -13,9 +13,9 @@
     "@ecl-twig/ec-component-link": "2.28.1"
   },
   "devDependencies": {
-    "@ecl/ec-component-gallery": "2.28.0",
-    "@ecl/ec-resources-icons": "2.28.0",
-    "@ecl/ec-specs-gallery": "2.28.0"
+    "@ecl/ec-component-gallery": "2.29.0",
+    "@ecl/ec-resources-icons": "2.29.0",
+    "@ecl/ec-specs-gallery": "2.29.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,6 +1680,15 @@
 "@ecl-twig/data-utils@file:utils/data-utils":
   version "0.0.0-dev-only"
 
+"@ecl-twig/ec-component-gallery@2.28.1":
+  version "2.28.1"
+  resolved "https://registry.yarnpkg.com/@ecl-twig/ec-component-gallery/-/ec-component-gallery-2.28.1.tgz#5e2e96ca4552892ee27c2126931f06391c66fa5b"
+  integrity sha512-AO9phkT66S3En5qVBCsEHabxcrTU5C9iiclqSeDQeSP2U01TMUtbAiSbgO8cinA7R2IOhurKI16R7NSOG5KLNA==
+  dependencies:
+    "@ecl-twig/ec-component-button" "2.28.1"
+    "@ecl-twig/ec-component-icon" "2.28.1"
+    "@ecl-twig/ec-component-link" "2.28.1"
+
 "@ecl-twig/php-storybook@file:php/php_storybook":
   version "0.0.1-alpha"
 
@@ -1705,6 +1714,11 @@
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-base/-/ec-base-2.28.0.tgz#6315bbc6edc72abaa04df400336453094fe408a1"
   integrity sha512-4oGSSElpbRzJ/2zs6EwzHv0HfZqPAwwFzJazwt1Aib7iyLJO1oMUUnuqVUN9b2Sf7lYBIIf3EJTgz3gTOsvRNw==
+
+"@ecl/ec-base@^2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-base/-/ec-base-2.29.0.tgz#cbcb43cad6b724e55893d111d93dba1ee7adad28"
+  integrity sha512-/jaeKWd49Bj7PuwZOFkmmS8sPyu8xidQ3RKoJFXI4pyQYWTqG0sZiJKLuWlruAGX7mIAedZU1zCL1sWhhJUCxQ==
 
 "@ecl/ec-component-accordion@2.28.0":
   version "2.28.0"
@@ -1936,12 +1950,12 @@
   dependencies:
     "@ecl/ec-base" "^2.28.0"
 
-"@ecl/ec-component-gallery@2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@ecl/ec-component-gallery/-/ec-component-gallery-2.28.0.tgz#edc45d56df490658c0674c79d7fcd59072ca15ce"
-  integrity sha512-8SNJxYhPYjGSTTG4jvqxI5R5M1LhI158DVNnUWPxp7l/ZHfepiMKqXYA2g4BYt4F1wqeL69c2WjHbPpHelTQ2Q==
+"@ecl/ec-component-gallery@2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-component-gallery/-/ec-component-gallery-2.29.0.tgz#9d0c7b66f998cf50926a21cebb5489402ff63b7d"
+  integrity sha512-ryuvTd/ymVry6ms91OKV5uwcjkC/M5vcasAxQ5NOk2NfkGepqieC+C728oLFXe6reLOTISa5cBiWtE6Zvji0og==
   dependencies:
-    "@ecl/ec-base" "^2.28.0"
+    "@ecl/ec-base" "^2.29.0"
     focus-trap "5.1.0"
 
 "@ecl/ec-component-hero-banner@2.28.0":
@@ -2200,6 +2214,11 @@
   resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.28.0.tgz#526ca5d4a7a228277d6049b314b8dd48d7da8cb9"
   integrity sha512-pj/FEyXF1sEpO1fC1oQB88SrDJnp3ZMWceYU/ecGshtwYqllqEOVZLPmBHPsUbOcoVo6tL81tLGXGHQF9Qh3ZQ==
 
+"@ecl/ec-resources-icons@2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-resources-icons/-/ec-resources-icons-2.29.0.tgz#a9b3792a9d5d153bafa71b0aa808d3ea01041ff4"
+  integrity sha512-qswabW3JfPdSDfkbWjE44Sok7raiHSeDITTPl+oRO3LxjOR+qWs0llm5y8WFrBQjtuZiywYQ1rE1FuR1OCkLog==
+
 "@ecl/ec-resources-logo@2.28.0":
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/@ecl/ec-resources-logo/-/ec-resources-logo-2.28.0.tgz#8506040188aaf8ecd92d575aa6500b71ae8e1220"
@@ -2320,10 +2339,10 @@
   resolved "https://registry.yarnpkg.com/@ecl/ec-specs-footer/-/ec-specs-footer-2.28.0.tgz#26c2dcdb2b9e047d1fe1600f826e8aa8831ede2a"
   integrity sha512-+Ade/K/a7VyDAKPkxzQuuubEzCOK82TTLTI5dLClTzqoDEf8LIXVvRg8oO1QBkgERp9EDIOyeisIsHz4ShvAKA==
 
-"@ecl/ec-specs-gallery@2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@ecl/ec-specs-gallery/-/ec-specs-gallery-2.28.0.tgz#1a30849bba28ce85368fded18b1cb50b3fcb692f"
-  integrity sha512-eNFqBbWU3UWxyVuY4eYVnwHDv55vvEx842b7MhVwR1TbMqSnt692zCGPcIuMOfbAJh+DvxZoz4rcIRIMBiP31Q==
+"@ecl/ec-specs-gallery@2.29.0":
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/@ecl/ec-specs-gallery/-/ec-specs-gallery-2.29.0.tgz#72225ea5b613f4db5397fd50df41e3b06a74e5d2"
+  integrity sha512-0ecO+2/Mh27e6OZIKi/gyVXHnk2e8QDkzIMAD+G/w2pnVZw8JSPKkJ9ZcJw/5NGJZYk13heuvXundyqtbOyF5A==
 
 "@ecl/ec-specs-hero-banner@2.28.0":
   version "2.28.0"


### PR DESCRIPTION
# PR description

Component aligned with ecl 2.29.0.

It is possible to retrieve the diff between our rendered html and the ecl one:
`yarn check:component ec gallery`
`yarn ecl-diff ec`, 
choose gallery, all the other options are already fine, just skip them.