### PR TITLE
fix(raw-filter): Using raw in safe context to avoid double escaping - FRONT-1940

### DIFF
--- a/php/php-storybook/bootstrap.php
+++ b/php/php-storybook/bootstrap.php
@@ -14,5 +14,5 @@ $eu_packages_folder = Path::canonicalize(__DIR__ . '/../../src/eu/packages/');
 $loader = new \Twig\Loader\FilesystemLoader($ec_packages_folder);
 $loader->addPath($eu_packages_folder, 'ecl-twig');
 $loader->addPath($ec_packages_folder, 'ecl-twig');
-$twig = new \Twig\Environment($loader);
+$twig = new \Twig\Environment($loader, ['autoescape' => false]);
 

--- a/src/ec/packages/ec-component-accordion/ecl-accordion.html.twig
+++ b/src/ec/packages/ec-component-accordion/ecl-accordion.html.twig
@@ -40,9 +40,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -50,7 +50,7 @@
 {# Print the result #}
 
 <div
-  class="{{ _css_class }}"{{ _extra_attributes }}
+  class="{{ _css_class }}"{{ _extra_attributes|raw }}
   data-ecl-accordion="true"
 >
   {% if _items is not empty %}

--- a/src/ec/packages/ec-component-accordion2/ecl-accordion2.html.twig
+++ b/src/ec/packages/ec-component-accordion2/ecl-accordion2.html.twig
@@ -40,9 +40,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -50,7 +50,7 @@
 {# Print the result #}
 
 <div
-  class="{{ _css_class }}" {{ _extra_attributes }}
+  class="{{ _css_class }}" {{ _extra_attributes|raw }}
   data-ecl-accordion2
 >
   {% if _items is not empty %}

--- a/src/ec/packages/ec-component-blockquote/ecl-blockquote.html.twig
+++ b/src/ec/packages/ec-component-blockquote/ecl-blockquote.html.twig
@@ -31,16 +31,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<blockquote class="{{ _css_class }}"{{ _extra_attributes }}>
+<blockquote class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <p class="ecl-blockquote__body">{{ _citation }}</p>
   <footer class="ecl-blockquote__attribution"><cite class="ecl-blockquote__author">{{ _author }}</cite></footer>
 </blockquote>

--- a/src/ec/packages/ec-component-breadcrumb-core/ecl-breadcrumb-core.html.twig
+++ b/src/ec/packages/ec-component-breadcrumb-core/ecl-breadcrumb-core.html.twig
@@ -80,15 +80,15 @@
 
 {% for attr in extra_attributes %}
   {% if attr.value is defined %}
-    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
   {% else %}
-    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
   {% endif %}
 {% endfor %}
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes }}>
+<nav class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <ol class="ecl-breadcrumb-core__container">
   {% if _links is not empty %}
     {% for key, link in _links %}
@@ -96,7 +96,7 @@
       {# Last item is not a link. #}
       {% if loop.last %}
         {% set _breadcrumb_segment_attributes = _breadcrumb_segment_attributes ~ ' aria-current="page"' %}
-        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb-core__current-page' }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb-core__current-page' }}" {{ _breadcrumb_segment_attributes|raw }}>
           {{- link.label -}}
         </li>
       {% else %}
@@ -122,7 +122,7 @@
           {% endif %}
         {% endif %}
         {# Render all the items with different attributes, aria labels are set via js #}
-        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes|raw }}>
           {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
             link: link|default({})|merge({
               type: 'standalone',

--- a/src/ec/packages/ec-component-breadcrumb-harmonised/ecl-breadcrumb-harmonised.html.twig
+++ b/src/ec/packages/ec-component-breadcrumb-harmonised/ecl-breadcrumb-harmonised.html.twig
@@ -81,15 +81,15 @@
 
 {% for attr in extra_attributes %}
   {% if attr.value is defined %}
-    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
   {% else %}
-    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
   {% endif %}
 {% endfor %}
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes }}>
+<nav class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <ol class="ecl-breadcrumb-harmonised__container">
   {% if _links is not empty %}
     {% for key, link in links %}
@@ -97,7 +97,7 @@
       {# Last item is not a link. #}
       {% if loop.last %}
         {% set _breadcrumb_segment_attributes = _breadcrumb_segment_attributes ~ ' aria-current="page"' %}
-        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb-harmonised__current-page' }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb-harmonised__current-page' }}" {{ _breadcrumb_segment_attributes|raw }}>
           {{- link.label -}}
         </li>
       {% else %}
@@ -123,7 +123,7 @@
           {% endif %}
         {% endif %}
         {# Render all the items with different attributes, aria labels are set via js #}
-        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes|raw }}>
           {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
             link: link|default({})|merge({
               type: 'standalone'

--- a/src/ec/packages/ec-component-breadcrumb-standardised/ecl-breadcrumb-standardised.html.twig
+++ b/src/ec/packages/ec-component-breadcrumb-standardised/ecl-breadcrumb-standardised.html.twig
@@ -80,22 +80,22 @@
 
 {% for attr in extra_attributes %}
   {% if attr.value is defined %}
-    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
   {% else %}
-    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+    {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
   {% endif %}
 {% endfor %}
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes }}>
+<nav class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <ol class="ecl-breadcrumb-standardised__container">
     {% for key, link in links %}
       {% set _breadcrumb_segment_attributes = 'data-ecl-breadcrumb-standardised-item="static"' %}
       {# Last item is not a link. #}
       {% if loop.last %}
         {% set _breadcrumb_segment_attributes = _breadcrumb_segment_attributes ~ ' aria-current="page"' %}
-        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb-standardised__current-page' }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb-standardised__current-page' }}" {{ _breadcrumb_segment_attributes|raw }}>
           {{- link.label -}}
         </li>
       {% else %}
@@ -121,7 +121,7 @@
           {% endif %}
         {% endif %}
         {# Render all the items with different attributes, aria labels are set via js #}
-        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes|raw }}>
           {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
             link: link|default({})|merge({
               type: 'standalone'

--- a/src/ec/packages/ec-component-breadcrumb/ecl-breadcrumb.html.twig
+++ b/src/ec/packages/ec-component-breadcrumb/ecl-breadcrumb.html.twig
@@ -69,23 +69,23 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}" {{ _extra_attributes }}>
+<nav class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <ol class="ecl-breadcrumb__container">
   {% if _links is not empty %}
     {% for key, link in links %}
       {% set _breadcrumb_segment_attributes = 'data-ecl-breadcrumb-item="static" aria-hidden="false"' %}
       {% if loop.last %}
         {% set _breadcrumb_segment_attributes = _breadcrumb_segment_attributes ~ ' aria-current="page"' %}
-        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb__current-page' }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class ~ ' ecl-breadcrumb__current-page' }}" {{ _breadcrumb_segment_attributes|raw }}>
           {{- link.label -}}
         </li>
       {% else %}
@@ -98,7 +98,7 @@
           {% endif %}
           {% set _breadcrumb_segment_attributes = 'data-ecl-breadcrumb-item="expandable" aria-hidden="true"' %}
         {% endif %}
-        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes }}>
+        <li class="{{ _breadcrumb_segment_class }}" {{ _breadcrumb_segment_attributes|raw }}>
           {% include '@ecl-twig/ec-component-link/ecl-link.html.twig' with {
             link: {
               type: 'standalone',

--- a/src/ec/packages/ec-component-button/ecl-button.html.twig
+++ b/src/ec/packages/ec-component-button/ecl-button.html.twig
@@ -44,9 +44,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -59,7 +59,7 @@
 
 {# Print the result #}
 
-<button class="{{ _css_class }}" type="{{ _type }}" {{ _extra_attributes }}>
+<button class="{{ _css_class }}" type="{{ _type }}" {{ _extra_attributes|raw }}>
   {%- if _icon.name is not empty %}
     <span class="ecl-button__container">
       {% if _icon_position == 'before' %}

--- a/src/ec/packages/ec-component-card/ecl-card.html.twig
+++ b/src/ec/packages/ec-component-card/ecl-card.html.twig
@@ -75,20 +75,20 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<article class="{{ _css_class }}"{{ _extra_attributes }}>
+<article class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <header class="ecl-card__header">
     {% if _card.image.src is defined and _card.image.src is not empty %}
-      {% set _card_img_aria_label = _card.image.alt is defined and _card.image.alt is not empty ? 'aria-label="' ~ _card.image.alt ~ '"' : '' %}
-      <div class="ecl-card__image" {{ _card_img_aria_label }} role="img" style="background-image:url('{{ _card.image.src }}')"></div>
+      {% set _card_img_aria_label = _card.image.alt is defined and _card.image.alt is not empty ? 'aria-label="' ~ _card.image.alt|e('html_attr') ~ '"' : '' %}
+      <div class="ecl-card__image" {{ _card_img_aria_label|raw }} role="img" style="background-image:url('{{ _card.image.src }}')"></div>
     {% endif %}
     {% if _card.meta is not empty %}
       <div class="ecl-card__meta">{{ _card.meta|join(" | ") }}</div>

--- a/src/ec/packages/ec-component-checkbox/ecl-checkbox-button.html.twig
+++ b/src/ec/packages/ec-component-checkbox/ecl-checkbox-button.html.twig
@@ -59,16 +59,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <input
     name="{{ _name }}"
     class="ecl-checkbox__input"

--- a/src/ec/packages/ec-component-checkbox/ecl-checkbox-group.html.twig
+++ b/src/ec/packages/ec-component-checkbox/ecl-checkbox-group.html.twig
@@ -49,9 +49,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -63,7 +63,7 @@
 {% if _helper_id is not empty %}
   aria-describedby="{{ _helper_id }}"
 {% endif %}
-  {{ _extra_attributes }}
+  {{ _extra_attributes|raw }}
 >
   {%- if _label is not empty %}
     <legend

--- a/src/ec/packages/ec-component-contextual-navigation/ecl-contextual-navigation.html.twig
+++ b/src/ec/packages/ec-component-contextual-navigation/ecl-contextual-navigation.html.twig
@@ -34,9 +34,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -44,7 +44,7 @@
 {# Print the result #}
 
 <nav
-  class="{{ _css_class }}"{{ _extra_attributes }}
+  class="{{ _css_class }}"{{ _extra_attributes|raw }}
   data-ecl-contextual-navigation
 >
   <div class="ecl-contextual-navigation__label">{{ _label }}</div>

--- a/src/ec/packages/ec-component-date-block/__snapshots__/date-block.test.js.snap
+++ b/src/ec/packages/ec-component-date-block/__snapshots__/date-block.test.js.snap
@@ -176,6 +176,29 @@ exports[`EC - Date Block renders correctly with time set 1`] = `
 
 exports[`EC - Date Block with validation enabled and missing input data returns the right warning message 1`] = `
 <test>
+  <time
+    class="ecl-date-block"
+    datetime="2019-09-26"
+  >
+    <span
+      class="ecl-u-sr-only"
+    >
+      2019-09-26
+    </span>
+    <span
+      aria-hidden="true"
+      class="ecl-date-block__day"
+    >
+      26
+    </span>
+    <abbr
+      aria-hidden="true"
+      class="ecl-date-block__month"
+      title="September"
+    >
+      Sep
+    </abbr>
+  </time>
   <!-- ecl2-compliance: date-block -->
   <div
     class="ecl2-compliance ecl-u-border-width-1 ecl-u-border-color-red ecl-u-border-style-solid ecl-u-ma-xs ecl-u-pr-s ecl-u-bg-white"

--- a/src/ec/packages/ec-component-date-block/ecl-date-block.html.twig
+++ b/src/ec/packages/ec-component-date-block/ecl-date-block.html.twig
@@ -41,32 +41,38 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
-{% if (_month is not empty or _month_full is not empty) and _year is not empty %}
-  {% if _month_full is not empty and _month_full != _month %}
-    {% set _month_markup = '<abbr title="' ~ _month_full ~ '" class="ecl-date-block__month" aria-hidden="true">' ~ _month ~ '</abbr>' %}
-  {% else %}
-    {% set _month_markup = '<span class="ecl-date-block__month">' ~ _month ~ '</span>' %}
-  {% endif %}
-  {% if _date_time is not empty %}
-    {% set _extra_attributes = _extra_attributes ~ 'dateTime="' ~ _date_time ~ '"' %}
-  {% endif %}
-
-  <time class="{{ _css_class }}"{{ _extra_attributes }}>
-    {% if _date_time is not empty %}
-      <span class="ecl-u-sr-only">{{ _date_time }}</span>
-    {% endif %}
-    <span class="ecl-date-block__day" aria-hidden="true">{{ _day }}</span>
-    {{ _month_markup }}
-    <span class="ecl-date-block__year" aria-hidden="true">{{ _year }}</span>
-  </time>
+{% if _date_time is not empty %}
+  {% set _extra_attributes = _extra_attributes ~ 'dateTime="' ~ _date_time|e('html_attr') ~ '"' %}
 {% endif %}
+
+<time class="{{ _css_class }}"{{ _extra_attributes|raw }}>
+  {% if _date_time is not empty %}
+    <span class="ecl-u-sr-only">{{ _date_time }}</span>
+  {% endif %}
+  <span class="ecl-date-block__day" aria-hidden="true">{{ _day }}</span>
+{% if (_month is not empty or _month_full is not empty) %}
+  {% if _month_full is not empty and _month_full != _month %}
+  <abbr
+    title="{{ _month_full|e('html_attr') }}"
+    class="ecl-date-block__month"
+    aria-hidden="true">
+      {{- _month -}}
+  </abbr>
+  {% else %}
+  <span class="ecl-date-block__month">{{ _month }}</span>
+  {% endif %}
+{% endif %}
+{% if _year is not empty %}
+  <span class="ecl-date-block__year" aria-hidden="true">{{ _year }}</span>
+{% endif %}
+</time>
 
 {# Validation #}
 

--- a/src/ec/packages/ec-component-datepicker/ecl-datepicker.html.twig
+++ b/src/ec/packages/ec-component-datepicker/ecl-datepicker.html.twig
@@ -67,9 +67,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -102,7 +102,7 @@
 {% endif %}
   <div
     class="{{ _css_class }}"
-    {{ _extra_attributes }}
+    {{ _extra_attributes|raw }}
   >
     <input
       data-ecl-datepicker-toggle

--- a/src/ec/packages/ec-component-description-list/ecl-description-list.html.twig
+++ b/src/ec/packages/ec-component-description-list/ecl-description-list.html.twig
@@ -41,9 +41,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -51,7 +51,7 @@
 {# Print the result #}
 
 {% if _items is not empty and _items is iterable %}
-  <dl class="{{ _css_class }}"{{ _extra_attributes }}>
+  <dl class="{{ _css_class }}"{{ _extra_attributes|raw }}>
     {% for _item in _items %}
       {% if _item.term is not empty %}
         {% if _item.term is iterable %}

--- a/src/ec/packages/ec-component-dropdown-legacy/ecl-dropdown-legacy.html.twig
+++ b/src/ec/packages/ec-component-dropdown-legacy/ecl-dropdown-legacy.html.twig
@@ -65,16 +65,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% include '@ecl-twig/ec-component-button/ecl-button.html.twig' with _button only %}
   <div
     id="{{ _id ~ '-content' }}"

--- a/src/ec/packages/ec-component-ecl-compliance/ecl-compliance.html.twig
+++ b/src/ec/packages/ec-component-ecl-compliance/ecl-compliance.html.twig
@@ -38,7 +38,7 @@
 {% if not_compliant %}
   {% block complaints %}
     {% if _icon_path is not empty and _compliance_inner_check %}
-      <span class="ecl-u-type-color-red ecl-compliance-inner ecl-compliance-failure ecl-u-ma-2xs" title="{{ _message }}">
+      <span class="ecl-u-type-color-red ecl-compliance-inner ecl-compliance-failure ecl-u-ma-2xs" title="{{ _message|raw }}">
       {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
           icon: { type: 'notifications', name: 'error', size: 'xs', path: _icon_path },
         } only %}
@@ -48,7 +48,7 @@
       class="ecl2-compliance ecl-u-border-width-1 ecl-u-border-color-red ecl-u-border-style-solid ecl-u-ma-xs ecl-u-pr-s ecl-u-bg-white"
     >
       <p class="ecl-u-type-color-grey ecl-u-ml-m ecl-u-type-xs">
-        {{- _message -}}
+        {{- _message|raw -}}
       </p>
     </div>
   {% endif %}
@@ -56,7 +56,7 @@
 {% else %}
   {% block compliant %}
     {% if _icon_path is not empty and _compliance_inner_check %}
-      <span class="ecl-u-type-color-green ecl-compliance-inner ecl-compliance-success ecl-u-ma-2xs" title="{{ _success_message }}">
+      <span class="ecl-u-type-color-green ecl-compliance-inner ecl-compliance-success ecl-u-ma-2xs" title="{{ _success_message|raw }}">
       {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
           icon: { type: 'notifications', name: 'success', size: 'xs', path: _icon_path },
         } only %}
@@ -66,7 +66,7 @@
         class="ecl2-compliance ecl-u-border-width-1 ecl-u-border-color-green ecl-u-border-style-solid ecl-u-ma-xs ecl-u-pr-s ecl-u-bg-white"
       >
         <p class="ecl-u-type-color-grey ecl-u-ml-s ecl-u-type-xs">
-          {{- _success_message -}}
+          {{- _success_message|raw -}}
         </p>
       </div>
     {% endif %}

--- a/src/ec/packages/ec-component-expandable/ecl-expandable.html.twig
+++ b/src/ec/packages/ec-component-expandable/ecl-expandable.html.twig
@@ -51,16 +51,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% set _label = _label_collapsed %}
   {% set _button_attributes = [
     { name: 'aria-controls', value: _aria_controls },
@@ -90,7 +90,7 @@
     class="{{ _css_dropdown_class }}"
     hidden
   >
-    {%- block content _content -%}
+    {{- content -}}
   </div>
 </div>
 

--- a/src/ec/packages/ec-component-expandable/ecl-expandable.html.twig
+++ b/src/ec/packages/ec-component-expandable/ecl-expandable.html.twig
@@ -90,7 +90,7 @@
     class="{{ _css_dropdown_class }}"
     hidden
   >
-    {{- content -}}
+    {%- block content _content -%}
   </div>
 </div>
 

--- a/src/ec/packages/ec-component-fact-figures/ecl-fact-figures.html.twig
+++ b/src/ec/packages/ec-component-fact-figures/ecl-fact-figures.html.twig
@@ -45,14 +45,14 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
 
 {% if items is defined and items is not empty and items is iterable %}
   <div class="ecl-fact-figures__items">

--- a/src/ec/packages/ec-component-file-upload/ecl-file-upload.html.twig
+++ b/src/ec/packages/ec-component-file-upload/ecl-file-upload.html.twig
@@ -63,11 +63,11 @@
 {# Internal logic - Process properties #}
 
 {% if _id is not empty %}
-  {% set _main_attributes = _main_attributes ~ ' ' ~ 'id="' ~ _id ~ '"' %}
+  {% set _main_attributes = _main_attributes ~ ' ' ~ 'id="' ~ _id|e('html_attr') ~ '"' %}
 {% endif %}
 
 {% if _name is not empty %}
-  {% set _main_attributes = _main_attributes ~ ' ' ~ 'name="' ~ _name ~ '"' %}
+  {% set _main_attributes = _main_attributes ~ ' ' ~ 'name="' ~ _name|e('html_attr') ~ '"' %}
 {% endif %}
 
 {% if _required %}
@@ -96,9 +96,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -166,9 +166,9 @@
   <input
     type="file"
     class="{{ _component_class }}"
-    {{- _main_attributes -}}
+    {{- _main_attributes|raw -}}
   {% if _extra_attributes is not empty %}
-    {{- _extra_attributes -}}
+    {{- _extra_attributes|raw -}}
   {% endif %}
   />
 

--- a/src/ec/packages/ec-component-file/ecl-file.html.twig
+++ b/src/ec/packages/ec-component-file/ecl-file.html.twig
@@ -62,9 +62,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -80,7 +80,7 @@
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-file__container">
   {% if _variant == 'thumbnail' %}
     <div class="ecl-file__detail">

--- a/src/ec/packages/ec-component-footer-core/ecl-footer-core.html.twig
+++ b/src/ec/packages/ec-component-footer-core/ecl-footer-core.html.twig
@@ -37,16 +37,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<footer class="{{ _css_class }}"{{ _extra_attributes }}>
+<footer class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <div class="ecl-container ecl-footer-core__container">
 {% if _sections is not empty and _sections is iterable %}
   {% set _section_id = 0 %}

--- a/src/ec/packages/ec-component-footer-harmonised/ecl-footer-harmonised.html.twig
+++ b/src/ec/packages/ec-component-footer-harmonised/ecl-footer-harmonised.html.twig
@@ -51,16 +51,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<footer class="{{ _css_class }}"{{ _extra_attributes }}>
+<footer class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {# Main container #}
   <div class="ecl-container ecl-footer-harmonised__container">
   {% for _full_section in _sections %}

--- a/src/ec/packages/ec-component-footer-standardised/ecl-footer-standardised.html.twig
+++ b/src/ec/packages/ec-component-footer-standardised/ecl-footer-standardised.html.twig
@@ -41,15 +41,15 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<footer class="{{ _css_class }}"{{ _extra_attributes }}>
+<footer class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {# Main container #}
   <div class="ecl-container ecl-footer-standardised__container">
   {% for _full_section in _sections %}

--- a/src/ec/packages/ec-component-footer/ecl-footer.html.twig
+++ b/src/ec/packages/ec-component-footer/ecl-footer.html.twig
@@ -41,16 +41,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<footer class="{{ _css_class }}"{{ _extra_attributes }}>
+<footer class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {# Back to top #}
   {# Disabled
   {% set _back_to_top = back_to_top|default({}) %}

--- a/src/ec/packages/ec-component-gallery/ecl-gallery-item.html.twig
+++ b/src/ec/packages/ec-component-gallery/ecl-gallery-item.html.twig
@@ -53,7 +53,7 @@
       {% set _image_alt = _item.alt %}
     {% endif %}
     {# Use Arial only for image. #}
-    {% set _use_arial = 'aria-label="' ~ _image_alt ~ '"' %}
+    {% set _use_arial = 'aria-label="' ~ _image_alt|e('html_attr') ~ '"' %}
   {% endif %}
   {% if _item.embedded_video is defined and _item.embedded_video is not empty %}
     {% set _media_iframe_href = _item.embedded_video.src %}
@@ -63,20 +63,20 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<li class="{{ _css_class }}"{{ _extra_attributes }}>
+<li class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <a
     href="{{ _media_iframe_href ? _media_iframe_href : _media_href }}"
     class="ecl-gallery__item-link"
-    {{ _use_arial }}
+    {{ _use_arial|raw }}
     data-ecl-gallery-item
     {% if _media_share_path is not empty %}
       data-ecl-gallery-item-share="{{ _media_share_path }}"

--- a/src/ec/packages/ec-component-gallery/ecl-gallery-overlay.html.twig
+++ b/src/ec/packages/ec-component-gallery/ecl-gallery-overlay.html.twig
@@ -37,16 +37,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<dialog class="{{ _css_class }}"{{ _extra_attributes }} data-ecl-gallery-overlay>
+<dialog class="{{ _css_class }}"{{ _extra_attributes|raw }} data-ecl-gallery-overlay>
   <header class="ecl-gallery__close" data-ecl-gallery-overlay-header>
     {% include '@ecl-twig/ec-component-button/ecl-button.html.twig' with _overlay.close|merge({
       extra_classes: 'ecl-gallery__close-button',

--- a/src/ec/packages/ec-component-gallery/ecl-gallery.html.twig
+++ b/src/ec/packages/ec-component-gallery/ecl-gallery.html.twig
@@ -54,16 +54,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<section class="{{ _css_class }}" {{ _extra_attributes }} data-ecl-gallery>
+<section class="{{ _css_class }}" {{ _extra_attributes|raw }} data-ecl-gallery>
   <ul class="ecl-gallery__list">
     {% for _item in _items %}
       {% set _item_class = '' %}

--- a/src/ec/packages/ec-component-hero-banner/ecl-hero-banner.html.twig
+++ b/src/ec/packages/ec-component-hero-banner/ecl-hero-banner.html.twig
@@ -47,15 +47,15 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _image is not empty and _type in ['image', 'image-shade', 'image-gradient'] %}
     <div class="ecl-hero-banner__image" style="background-image:url({{ _image }})"></div>
   {% endif %}

--- a/src/ec/packages/ec-component-icon/ecl-icon.html.twig
+++ b/src/ec/packages/ec-component-icon/ecl-icon.html.twig
@@ -88,9 +88,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -101,7 +101,7 @@
   class="{{ _css_class }}"
   focusable="false"
   aria-hidden="{{ _aria_hidden }}"
-  {{ _extra_attributes }}>
+  {{ _extra_attributes|raw }}>
 {% if _extra_accessibility.title is not empty %}
   <title
   {% if _extra_accessibility.title_id is not empty %}

--- a/src/ec/packages/ec-component-inpage-navigation/ecl-inpage-navigation.html.twig
+++ b/src/ec/packages/ec-component-inpage-navigation/ecl-inpage-navigation.html.twig
@@ -35,16 +35,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes }} data-ecl-inpage-navigation="true">
+<nav class="{{ _css_class }}"{{ _extra_attributes|raw }} data-ecl-inpage-navigation="true">
   <div class="ecl-inpage-navigation__title">{{ title }}</div>
   <div class="ecl-inpage-navigation__body">
     <button type="button" class="ecl-inpage-navigation__trigger"

--- a/src/ec/packages/ec-component-label/ecl-label.html.twig
+++ b/src/ec/packages/ec-component-label/ecl-label.html.twig
@@ -30,9 +30,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -41,7 +41,7 @@
 
 <span
   class="{{ _css_class }}"
-  {{ _extra_attributes }}
+  {{ _extra_attributes|raw }}
 >
   {{- _label -}}
 </span>

--- a/src/ec/packages/ec-component-language-list/ecl-language-list-grid.html.twig
+++ b/src/ec/packages/ec-component-language-list/ecl-language-list-grid.html.twig
@@ -32,7 +32,7 @@
 
 <div class="ecl-row ecl-language-list__{{ section }}">
   <div class="ecl-language-list__category ecl-col-12 ecl-col-lg-8 ecl-offset-lg-2">
-    {{- category -}}
+    {{- category|raw -}}
   </div>
   <div class="ecl-language-list__column ecl-col-12 ecl-col-lg-4 ecl-offset-lg-2">
     <ul class="ecl-language-list__list">

--- a/src/ec/packages/ec-component-language-list/ecl-language-list.html.twig
+++ b/src/ec/packages/ec-component-language-list/ecl-language-list.html.twig
@@ -65,16 +65,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }} {{ _data_lang_overlay }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }} {{ _data_lang_overlay }}>
 {% if _overlay %}
   <div class="ecl-language-list__container ecl-container">
     <div class="ecl-row">

--- a/src/ec/packages/ec-component-language-list/language-list.story.js
+++ b/src/ec/packages/ec-component-language-list/language-list.story.js
@@ -12,6 +12,7 @@ import {
   tabLabels,
   getComplianceKnob,
 } from '@ecl-twig/story-utils';
+import he from 'he';
 
 import logoPath from '@ecl/ec-resources-logo/logo--mute.svg';
 import euLogoPath from '@ecl/eu-resources-logo/logo--mute.svg';
@@ -73,11 +74,11 @@ const prepareLanguageList = (data) => {
   if (data.title) {
     data.title = text('title', data.title, tabLabels.required);
   }
-  data.eu_category = text('eu_category', data.eu_category, tabLabels.optional);
-  data.non_eu_category = text(
-    'non_eu_category',
-    data.non_eu_category,
-    tabLabels.optional
+  data.eu_category = he.decode(
+    text('eu_category', data.eu_category, tabLabels.optional)
+  );
+  data.non_eu_category = he.decode(
+    text('non_eu_category', data.non_eu_category, tabLabels.optional)
   );
   data.items.forEach((item, i) => {
     if (item.label && item.path) {

--- a/src/ec/packages/ec-component-link/ecl-link.html.twig
+++ b/src/ec/packages/ec-component-link/ecl-link.html.twig
@@ -92,9 +92,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -104,7 +104,7 @@
 <a
   href="{{ _link.path }}"
   class="{{ _css_class }}"
-  {{ _extra_attributes }}
+  {{ _extra_attributes|raw }}
 >
   {%- if _icons is defined and _link.icon_position == 'before' -%}
     {% for icon in _icons %}

--- a/src/ec/packages/ec-component-media-container/ecl-media-container.html.twig
+++ b/src/ec/packages/ec-component-media-container/ecl-media-container.html.twig
@@ -57,16 +57,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<figure class="{{ _css_class }}"{{ _extra_attributes }}>
+<figure class="{{ _css_class }}"{{ _extra_attributes|raw }}>
 {% if _embedded_media is not empty %}
   <div class="ecl-media-container__media ecl-media-container__media--ratio-{{ _ratio }}">
     {%- block embedded_media _embedded_media -%}

--- a/src/ec/packages/ec-component-menu-legacy/ecl-menu-legacy.html.twig
+++ b/src/ec/packages/ec-component-menu-legacy/ecl-menu-legacy.html.twig
@@ -61,15 +61,15 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<nav class="{{ _css_class }}" {{ _extra_attributes }}>
+<nav class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-container">
     <button
       class="{{ _prefix_class }}__toggle ecl-button ecl-button--ghost"

--- a/src/ec/packages/ec-component-menu/ecl-menu.html.twig
+++ b/src/ec/packages/ec-component-menu/ecl-menu.html.twig
@@ -61,9 +61,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -73,7 +73,7 @@
   data-ecl-menu
   data-ecl-auto-init="Menu"
   aria-expanded="false"
-  {{ _extra_attributes }}
+  {{ _extra_attributes|raw }}
 >
   <div class="ecl-menu__overlay" data-ecl-menu-overlay></div>
   <div class="ecl-container ecl-menu__container">

--- a/src/ec/packages/ec-component-message/ecl-message.html.twig
+++ b/src/ec/packages/ec-component-message/ecl-message.html.twig
@@ -42,16 +42,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" data-ecl-message role="alert"{{ _extra_attributes }}>
+<div class="{{ _css_class }}" data-ecl-message role="alert"{{ _extra_attributes|raw }}>
   {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
     icon: _icon,
     extra_classes: 'ecl-message__icon',

--- a/src/ec/packages/ec-component-ordered-list/ecl-ordered-list.html.twig
+++ b/src/ec/packages/ec-component-ordered-list/ecl-ordered-list.html.twig
@@ -39,16 +39,16 @@
   {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
     {% for attr in extra_attributes %}
       {% if attr.value is defined %}
-        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
       {% else %}
-        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
       {% endif %}
     {% endfor %}
   {% endif %}
 
   {# Print the result #}
   {% if _items is not empty %}
-    <ol class="{{ _css_class }}" {{ _extra_attributes }}>
+    <ol class="{{ _css_class }}" {{ _extra_attributes|raw }}>
       {% for _item in _items %}
         {% if _item is not empty %}
           <li class="ecl-ordered-list__item">

--- a/src/ec/packages/ec-component-page-banner/ecl-page-banner.html.twig
+++ b/src/ec/packages/ec-component-page-banner/ecl-page-banner.html.twig
@@ -46,16 +46,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<section class="{{ _css_class }}"{{ _extra_attributes }}>
+<section class="{{ _css_class }}"{{ _extra_attributes|raw }}>
 {% if _image is not empty and _type in ['image', 'image-shade', 'image-gradient'] %}
   <div class="ecl-page-banner__image" style="background-image:url({{ _image }})"></div>
 {% endif %}

--- a/src/ec/packages/ec-component-page-header-core/ecl-page-header-core.html.twig
+++ b/src/ec/packages/ec-component-page-header-core/ecl-page-header-core.html.twig
@@ -45,15 +45,15 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-container">
   {% if _breadcrumb is not empty %}
     {% include '@ecl-twig/ec-component-breadcrumb-core/ecl-breadcrumb-core.html.twig' with _breadcrumb|merge({

--- a/src/ec/packages/ec-component-page-header-harmonised/ecl-page-header-harmonised.html.twig
+++ b/src/ec/packages/ec-component-page-header-harmonised/ecl-page-header-harmonised.html.twig
@@ -32,15 +32,15 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-container">
   {% if _breadcrumb is not empty %}
     {% include '@ecl-twig/ec-component-breadcrumb-harmonised/ecl-breadcrumb-harmonised.html.twig' with _breadcrumb|merge({

--- a/src/ec/packages/ec-component-page-header-standardised/ecl-page-header-standardised.html.twig
+++ b/src/ec/packages/ec-component-page-header-standardised/ecl-page-header-standardised.html.twig
@@ -32,15 +32,15 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-container">
   {% if _breadcrumb is not empty %}
     {% include '@ecl-twig/ec-component-breadcrumb-standardised/ecl-breadcrumb-standardised.html.twig' with _breadcrumb|merge({

--- a/src/ec/packages/ec-component-page-header/ecl-page-header.html.twig
+++ b/src/ec/packages/ec-component-page-header/ecl-page-header.html.twig
@@ -64,15 +64,15 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <div class="ecl-container">
   {% if _breadcrumb is not empty %}
     {% include '@ecl-twig/ec-component-breadcrumb/ecl-breadcrumb.html.twig' with _breadcrumb|merge({

--- a/src/ec/packages/ec-component-pagination/ecl-pagination.html.twig
+++ b/src/ec/packages/ec-component-pagination/ecl-pagination.html.twig
@@ -36,16 +36,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<nav class="{{ _css_class }}"{{ _extra_attributes }} aria-label="{{ _label }}">
+<nav class="{{ _css_class }}"{{ _extra_attributes|raw }} aria-label="{{ _label }}">
   <ul class="ecl-pagination__list">
     {% for _item in _items %}
       <li class="ecl-pagination__item{{ _item.type ? ' ecl-pagination__item--' ~ _item.type }}">

--- a/src/ec/packages/ec-component-radio/ecl-radio-button.html.twig
+++ b/src/ec/packages/ec-component-radio/ecl-radio-button.html.twig
@@ -64,16 +64,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}" {{ _extra_attributes }}>
+<div class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <input
   {% if _id %}
      id="{{ _id }}"

--- a/src/ec/packages/ec-component-radio/ecl-radio-group.html.twig
+++ b/src/ec/packages/ec-component-radio/ecl-radio-group.html.twig
@@ -48,9 +48,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -62,7 +62,7 @@
 {% if _helper_id is not empty %}
    aria-describedby="{{ _helper_id }}"
 {% endif %}
-  {{ _extra_attributes }}
+  {{ _extra_attributes|raw }}
 >
 
   {%- if _label is not empty %}

--- a/src/ec/packages/ec-component-search-form/ecl-search-form.html.twig
+++ b/src/ec/packages/ec-component-search-form/ecl-search-form.html.twig
@@ -36,16 +36,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<form class="{{ _css_class }}" role="search"{{ _extra_attributes }}>
+<form class="{{ _css_class }}" role="search"{{ _extra_attributes|raw }}>
   {% if _text_input is not empty %}
     {% include '@ecl-twig/ec-component-text-input/ecl-text-input.html.twig' with _text_input|merge({
       type: 'search',

--- a/src/ec/packages/ec-component-select/ecl-select.html.twig
+++ b/src/ec/packages/ec-component-select/ecl-select.html.twig
@@ -87,9 +87,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -99,7 +99,7 @@
   {% if _label is not empty %}
     <label
     {% if _id %}
-      for="{{ _id }}"
+      for="{{ _id|e('html_attr') }}"
     {% endif %}
       class="ecl-form-label
       {{- _invalid ? ' ecl-form-label--invalid' -}}
@@ -136,7 +136,7 @@
       id="{{ _id }}"
     {% endif %}
     {% if _name is not empty %}
-      name="{{ _name }}"
+      name="{{ _name|e('html_attr') }}"
     {% endif %}
     {% if _required %}
       required
@@ -144,11 +144,11 @@
     {% if _disabled %}
       disabled
     {% endif %}
-      {{- _extra_attributes -}}
+      {{- _extra_attributes|raw -}}
     >
       {% for _option in _options %}
         <option
-          value="{{ _option.value }}"
+          value="{{ _option.value|e('html_attr') }}"
         {% if _option.selected %}
           selected
         {% endif %}

--- a/src/ec/packages/ec-component-site-header-core/ecl-site-header-core.html.twig
+++ b/src/ec/packages/ec-component-site-header-core/ecl-site-header-core.html.twig
@@ -178,16 +178,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<header class="{{ _css_class }}"{{ _extra_attributes }}>
+<header class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <div class="ecl-site-header-core__container ecl-container">
     <div class="ecl-site-header-core__top">
     {% if _logo is not empty %}

--- a/src/ec/packages/ec-component-site-header-harmonised/ecl-site-header-harmonised.html.twig
+++ b/src/ec/packages/ec-component-site-header-harmonised/ecl-site-header-harmonised.html.twig
@@ -194,16 +194,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<header class="{{ _css_class }}" {{ _extra_attributes }}>
+<header class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <div class="ecl-site-header-harmonised__container ecl-container">
     <div class="ecl-site-header-harmonised__top">
     {% if _logo is not empty %}

--- a/src/ec/packages/ec-component-site-header-standardised/ecl-site-header-standardised.html.twig
+++ b/src/ec/packages/ec-component-site-header-standardised/ecl-site-header-standardised.html.twig
@@ -189,16 +189,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<header class="{{ _css_class }}"{{ _extra_attributes }}>
+<header class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <div class="ecl-site-header-standardised__container ecl-container">
     <div class="ecl-site-header-standardised__top">
     {% if _logo is not empty %}

--- a/src/ec/packages/ec-component-site-header/ecl-site-header.html.twig
+++ b/src/ec/packages/ec-component-site-header/ecl-site-header.html.twig
@@ -111,16 +111,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<header class="{{ _css_class }}"{{ _extra_attributes }}>
+<header class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <div class="ecl-site-header__container ecl-container">
     <div class="ecl-site-header__banner">
       <a

--- a/src/ec/packages/ec-component-skip-link/ecl-skip-link.html.twig
+++ b/src/ec/packages/ec-component-skip-link/ecl-skip-link.html.twig
@@ -32,9 +32,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -42,7 +42,7 @@
 
 {# Print the result #}
 
-<a href="{{ _href }}" class="{{ _css_class }}" {{ _extra_attributes }}>
+<a href="{{ _href }}" class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   {{- _label -}}
 </a>
 

--- a/src/ec/packages/ec-component-social-media-follow/ecl-social-media-follow.html.twig
+++ b/src/ec/packages/ec-component-social-media-follow/ecl-social-media-follow.html.twig
@@ -54,16 +54,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <p class="ecl-social-media-follow__description">{{ _description }}</p>
 {% if _links is not empty %}
   <ul class="ecl-social-media-follow__list">

--- a/src/ec/packages/ec-component-social-media-share/ecl-social-media-share.html.twig
+++ b/src/ec/packages/ec-component-social-media-share/ecl-social-media-share.html.twig
@@ -49,16 +49,16 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<div class="{{ _css_class }}"{{ _extra_attributes }}>
+<div class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   <p class="ecl-social-media-share__description">{{ _description }}</p>
   {% if _links is not empty %}
     <ul class="ecl-social-media-share__list">

--- a/src/ec/packages/ec-component-table/ecl-table.html.twig
+++ b/src/ec/packages/ec-component-table/ecl-table.html.twig
@@ -72,29 +72,29 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
 
-<table class="{{ _css_class }}" {{ _extra_attributes }}>
+<table class="{{ _css_class }}" {{ _extra_attributes|raw }}>
   <thead class="{{ _head_css_class }}">
      {% for header in _headers %}
        <tr class="{{ _row_css_class }}">
         {% for cell in header %}
           {% set _heading_attribute = '' %}
           {% if cell.colspan is not empty %}
-            {% set _heading_attribute = cell.colspan is not empty ? 'colspan="' ~ cell.colspan ~ '"' : '' %}
+            {% set _heading_attribute = cell.colspan is not empty ? 'colspan="' ~ cell.colspan|e('html_attr') ~ '"' : '' %}
           {% else %}
             {% if cell.label is not empty and _sortable %}
               {% set _heading_attribute = 'data-ecl-table-sort-toggle' %}
             {% endif %}
           {% endif %}
-          <th {{ _heading_attribute }} class="{{ _header_css_class }}">{{ cell.label }}</th>
+          <th {{ _heading_attribute|raw }} class="{{ _header_css_class }}">{{ cell.label }}</th>
         {% endfor %}
       </tr>
     {% endfor %}
@@ -110,14 +110,14 @@
       <tr class="{{ _row_css_class }}"{{ _row_extra_attributes }}>
         {% for cell in row %}
           {% set _cell_css_class = 'ecl-table__cell' %}
-          {% set _cell_attribute = cell['data-ecl-table-header'] is not empty ? 'data-ecl-table-header="' ~ cell['data-ecl-table-header'] ~ '"' : '' %}
+          {% set _cell_attribute = cell['data-ecl-table-header'] is not empty ? 'data-ecl-table-header="' ~ cell['data-ecl-table-header']|e('html_attr') ~ '"' : '' %}
           {% if cell.group %}
             {% if cell['data-ecl-table-header-group'] is defined and cell['data-ecl-table-header-group'] is not empty %}
-              {% set _cell_attribute = _cell_attribute ~ ' data-ecl-table-header-group="' ~ cell['data-ecl-table-header-group'] ~ '"' %}
+              {% set _cell_attribute = _cell_attribute ~ ' data-ecl-table-header-group="' ~ cell['data-ecl-table-header-group']|e('html_attr') ~ '"' %}
             {% endif %}
             {% set _cell_css_class = _cell_css_class ~ ' ' ~ _cell_header_group_class %}
           {% endif %}
-          <td {{ _cell_attribute }} class="{{ _cell_css_class }}" >{{ cell.label }}</td>
+          <td {{ _cell_attribute|raw }} class="{{ _cell_css_class }}" >{{ cell.label }}</td>
         {% endfor %}
       </tr>
     {% endfor %}

--- a/src/ec/packages/ec-component-tag/ecl-tag.html.twig
+++ b/src/ec/packages/ec-component-tag/ecl-tag.html.twig
@@ -58,9 +58,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -68,18 +68,18 @@
 {# Print the result #}
 
 {% if _tag.type == 'link' %}
-  <a href="{{ _tag.path }}" class="{{ _css_class }}" {{ _extra_attributes }}>
+  <a href="{{ _tag.path }}" class="{{ _css_class }}" {{ _extra_attributes|raw }}>
     {{- _tag.label -}}
   </a>
 {% elseif _tag.type == 'button' %}
-  <button class="{{ _css_class }}" type="button" {{ _extra_attributes }}>
+  <button class="{{ _css_class }}" type="button" {{ _extra_attributes|raw }}>
     {{- _tag.label -}}
   </button>
 {% else %}
   <span class="{{ _css_class }}">
     {{- _tag.label -}}
   {%- if _tag.type == 'removable' -%}
-    <button type="button" {{ _extra_attributes }} class="ecl-tag__icon">
+    <button type="button" {{ _extra_attributes|raw }} class="ecl-tag__icon">
       {% include '@ecl-twig/ec-component-icon/ecl-icon.html.twig' with {
         icon: { type: 'ui', name: 'close', size: 'xs', path: _default_icon_path },
         extra_classes: 'ecl-tag__icon-close',

--- a/src/ec/packages/ec-component-text-area/ecl-text-area.html.twig
+++ b/src/ec/packages/ec-component-text-area/ecl-text-area.html.twig
@@ -66,9 +66,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -121,7 +121,7 @@
   {% if _required %}
     required
   {% endif %}
-    {{ _extra_attributes }}
+    {{ _extra_attributes|raw }}
   >
     {{- _default_value -}}
 </textarea>

--- a/src/ec/packages/ec-component-text-input/ecl-text-input.html.twig
+++ b/src/ec/packages/ec-component-text-input/ecl-text-input.html.twig
@@ -66,9 +66,9 @@
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
@@ -123,7 +123,7 @@
   {% if _required %}
     required
   {% endif %}
-    {{ _extra_attributes }}
+    {{ _extra_attributes|raw }}
   />
 
 </div>

--- a/src/ec/packages/ec-component-timeline/ecl-timeline.html.twig
+++ b/src/ec/packages/ec-component-timeline/ecl-timeline.html.twig
@@ -59,15 +59,15 @@ Parameters:
 {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
   {% for attr in extra_attributes %}
     {% if attr.value is defined %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
     {% else %}
-      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
     {% endif %}
   {% endfor %}
 {% endif %}
 
 {# Print the result #}
-<ol class="{{ _css_class }}"{{ _extra_attributes }}>
+<ol class="{{ _css_class }}"{{ _extra_attributes|raw }}>
   {% if _items is not empty %}
     {% for _item in _items %}
       {# Decide on per item if it should display. #}

--- a/src/ec/packages/ec-component-unordered-list/ecl-unordered-list.html.twig
+++ b/src/ec/packages/ec-component-unordered-list/ecl-unordered-list.html.twig
@@ -46,16 +46,16 @@
   {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
     {% for attr in extra_attributes %}
       {% if attr.value is defined %}
-        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
+        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') ~ '="' ~ attr.value|e('html_attr') ~ '"' %}
       {% else %}
-        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name %}
+        {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name|e('html_attr') %}
       {% endif %}
     {% endfor %}
   {% endif %}
 
   {# Print the result #}
   {% if _items is not empty %}
-    <ul class="{{ _css_class }}"{{ _extra_attributes }}>
+    <ul class="{{ _css_class }}"{{ _extra_attributes|raw }}>
       {% for _item in _items %}
         {% if _item is not empty %}
           <li class="ecl-unordered-list__item">

--- a/utils/story-utils/src/index.js
+++ b/utils/story-utils/src/index.js
@@ -426,15 +426,19 @@ export const getLanguageSelectorKnobs = (data, required, deprecated) => {
   if (required) {
     label = tabLabels.required;
   }
-  data.language_selector.eu_category = text(
-    'language_selector.eu_category',
-    data.language_selector.eu_category,
-    label
+  data.language_selector.eu_category = he.decode(
+    text(
+      'language_selector.eu_category',
+      data.language_selector.eu_category,
+      label
+    )
   );
-  data.language_selector.non_eu_category = text(
-    'language_selector.non_eu_category',
-    data.language_selector.non_eu_category,
-    label
+  data.language_selector.non_eu_category = he.decode(
+    text(
+      'language_selector.non_eu_category',
+      data.language_selector.non_eu_category,
+      label
+    )
   );
   data.language_selector.href = text(
     'language_selector.href',


### PR DESCRIPTION
Some explanation:
we blindly followed the request by the platform of removing all the raw filter usages in the library, first, and this lead to some, different misbehaviours:

- In our scenario, all the specs containing html would cause escaping by the twig engine and the html would be rendered as a string, this is not a problem on platform side because with drupal you have ways to mark your html as "safe" for twig.
- Due to this we told twing not to autoescape in 2.35.1 and by doing this we fixed the problem on our side, in the js storybook
- We did not do the same for php and indeed the demo in https://ecl-twig-php.netlify.app shows all the markup in variables as a string. (https://ecl-twig-php.netlify.app/ec/?path=/story/components-timeline--default as an example)
- It's worth mentioning that after a long discussion, drupal 8 enabled the autoescape in twig, which indeed created many issues, but they stick to that, due to the security holes that they were otherwise having.
- There are a few different use cases of html in variables in our templates, one is the aforementioned "specs" property that contains html, but also in many other cases we were storing html in variables and by removing the raw filter we made them appear as strings, as long as the autoescape was in place (https://ecl-twig-php.netlify.app/ec/?path=/story/components-date-block--default).
- In this pr what happens is that we reintroduce the raw filter for attributes, because of the way we build them, indeed, they would be double escaped and this would completely break the js (this is what is in the issue: https://citnet.tech.ec.europa.eu/CITnet/jira/browse/FRONT-1940),  all the strings provided to the template for the attributes in this regard are escaped with the html_attr strategy in the template, so that's why we can then safely use raw when we print the string we built.
- Mainly this is a story about attributes, but there we other cases where the templates were storing markup in variables, this would break when not printing them with raw, so in some other cases code was reorganised in order not to store html in variable (the date block component, for instance).
- Still the autoescape needs to be disabled in our scenario because all the demoes with specs containing html would break but this is risky, because we have to take care, from now on, of not storing html in variables, we would not see the problem generated by this due to the fact that we don't have the twig autoescape in place.
- The test have been run one by one to ensure, before disabling the autoescape, that the only "breaking" things were about data provided by the specs, so i'm fairly confident that the templates are now ok, but if you really want to test this, please remove the `autoescape: false` from the` environment.js` file in the ec storybook folder and run the test, the things breaking should all be related to data provided by the specs.
- As a final consideration, though, i'm confused about what platform asked us in https://citnet.tech.ec.europa.eu/CITnet/jira/browse/FRONT-1909, they showed us a patch where they were using `e('html_attr')` for the attributes but you can see here https://twig.symfony.com/doc/1.x/filters/escape.html that the `html_attr `strategy for escaping has been added in twig 1.9, platform is using, in the most recent version, 1.44, so i don't know...

# PR description

Please drop a few lines about the PR: what it does, how to test it, etc.

## QA Checklist

In order to ensure a safe and quick review, please check that your PR follow those guidelines:

- [ ] I have put the vanilla component as `devDependencies`
- [ ] I have put the specs package as `devDependencies`
- [ ] I have added the components directly used in the twig file (with `include` or `embed`) as `dependencies`
- [ ] My component is listed in `@ecl-twig/ec-components`'s `dependencies`
- [ ] My variables naming follow the guidelines (snake case for twig)
- [ ] I have provided tests
- [ ] I have provided documentation (for the "notes" tab)
- [ ] If my local `yarn.lock` contains changes, I have committed it
- [ ] I have given my PR the proper label (`pr: review needed` to indicate that I'm done and now waiting for a review ,`pr: wip` to indicate that I'm actively working on it ...)
